### PR TITLE
95-PY/wrong-metadata-value-separator-was-imported

### DIFF
--- a/dspace_import.py
+++ b/dspace_import.py
@@ -88,6 +88,8 @@ def read_metadata():
     if metadatavalue_json:
         for i in metadatavalue_json:
             key = (i['resource_type_id'], i['resource_id'])
+            #replace separator @@ by ;
+            i['text_value'] = i['text_value'].replace("@@", ";")
             if key in metadatavalue.keys():
                 metadatavalue[key].append(i)
             else:
@@ -717,7 +719,7 @@ def import_bundle():
     Import data into database.
     Mapped tables: item2bundle, bundle
     """
-    global item_id, handle, bundle_id
+    global item_id, bundle_id
     #load item2bundle into dict
     json_a = read_json("item2bundle.json")
     item2bundle = dict()
@@ -749,8 +751,6 @@ def import_bundle():
                     json_p['metadata'] = metadata_bundle
                     json_p['name'] = metadata_bundle['dc.title'][0]['value']
 
-                if bundle in handle:
-                    json_p['handle'] = handle[(1, bundle)]
                 try:
                     response = do_api_post('core/items/' + str(item_id[item[0]]) + "/bundles", None, json_p)
                     bundle_id[bundle] = convert_response_to_json(response)['uuid']
@@ -762,9 +762,9 @@ def import_bundle():
 def import_bitstream():
     """
     Import data into database.
-    Mapped tables: bitstream, bundle2bitstream, metadata, handle, most_recent_checksum and checksum_result
+    Mapped tables: bitstream, bundle2bitstream, metadata, most_recent_checksum and checksum_result
     """
-    global bitstreamformat_id, handle, primaryBitstream, bitstream2bundle
+    global bitstreamformat_id, primaryBitstream, bitstream2bundle
     #load bundle2bitstream
     json_a = read_json("bundle2bitstream.json")
     if json_a:
@@ -779,8 +779,6 @@ def import_bitstream():
             metadata_bitstream = get_metadata_value(0, i['bitstream_id'])
             if metadata_bitstream:
                 json_p['metadata'] = metadata_bitstream
-            if i['bitstream_id'] in handle:
-                json_p['handle'] = handle[(0, i['bitstream_id'])]
             json_p['sizeBytes'] = i['size_bytes']
             json_p['checkSum'] = {'checkSumAlgorithm': i['checksum_algorithm'], 'value': i['checksum']}
             params = {'internal_id': i['internal_id'],


### PR DESCRIPTION
We replace @@ by ;, if it was found in metadata value.