### PR TITLE
115-py/cannot-import-bitstream-with-sequence_id

### DIFF
--- a/dspace_import.py
+++ b/dspace_import.py
@@ -835,6 +835,7 @@ def import_bitstream():
             if i['bitstream_id'] in primaryBitstream:
                 params['primaryBundle_id'] = bundle_id[primaryBitstream[i['bitstream_id']]]
             try:
+                log('Going to process Bitstream with internal_id: ' + str(i['internal_id']))
                 response = do_api_post('clarin/import/core/bitstream', params, json_p)
                 bitstream_id[i['bitstream_id']] = convert_response_to_json(response)['id']
             except:


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  8  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description

