### PR TITLE
87-PY/added-missing-attributes-to-eperson

### DIFF
--- a/dspace_import.py
+++ b/dspace_import.py
@@ -356,7 +356,8 @@ def import_eperson():
             metadata = get_metadata_value(7, i['eperson_id'])
             json_p = {'selfRegistered': i['self_registered'], 'requireCertificate': i['require_certificate'],
                       'netid': i['netid'], 'canLogIn': i['can_log_in'], 'lastActive': i['last_active'],
-                      'email': i['email'], 'password': i['password']}
+                      'email': i['email'], 'password': i['password'], 'welcomeInfo': i['welcome_info'],
+                      'canEditSubmissionMetadata': i['can_edit_submission_metadata']}
             if metadata:
                 json_p['metadata'] = metadata
             if i['eperson_id'] in user_reg:


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.01  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In dspace5, there were two more attributes in eperson table: welcome_info and can_edit_submission_metadata.
## Analysis
Migrate these attributes too.
