### PR TITLE
ufal/py-two-clarin-licenses-not-imported

### DIFF
--- a/data_pump/eperson.py
+++ b/data_pump/eperson.py
@@ -37,7 +37,12 @@ def import_eperson(metadata_class,
             'welcomeInfo': eperson['welcome_info'],
             'canEditSubmissionMetadata': eperson['can_edit_submission_metadata']
         }
-        email2epersonId_dict[eperson['email']] = eperson['eperson_id']
+
+        # eperson email could consist of more emails, add eperson_id into everyone
+        eperson_email_array = get_eperson_emails(eperson['email'])
+        for eperson_email in eperson_email_array:
+            email2epersonId_dict[eperson_email] = eperson['eperson_id']
+
         if metadatavalue_eperson_dict:
             eperson_json_p['metadata'] = metadatavalue_eperson_dict
         params = {
@@ -61,6 +66,19 @@ def import_eperson(metadata_class,
     statistics_dict['eperson'] = statistics_val
     logging.info("Eperson was successfully imported!")
 
+
+'''
+The eperson email could consist of more email, return all of them in the array  
+'''
+
+
+def get_eperson_emails(email):
+    if ';' not in email:
+        return [email]
+
+    # email value contains of two email, take just the first one.
+    # e.g., test@msn.com;name@gmail.com
+    return email.split(';')
 
 def import_group2eperson(eperson_id_dict,
                          group_id_dict,

--- a/data_pump/eperson.py
+++ b/data_pump/eperson.py
@@ -73,6 +73,9 @@ The eperson email could consist of more email, return all of them in the array
 
 
 def get_eperson_emails(email):
+    if email is None:
+        return []
+
     if ';' not in email:
         return [email]
 

--- a/data_pump/eperson.py
+++ b/data_pump/eperson.py
@@ -67,12 +67,11 @@ def import_eperson(metadata_class,
     logging.info("Eperson was successfully imported!")
 
 
-'''
-The eperson email could consist of more email, return all of them in the array  
-'''
-
-
 def get_eperson_emails(email):
+    """
+    The eperson email could consist of more email, return all of them in the array.
+    If the email doesn't contain `;` that means there is only one email without `;` separator.
+    """
     if email is None:
         return []
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  2  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The emails from `eperson` and `user_registration` was different for some users e.g., in the `eperson.json` the user has email `test@edu.cz;test@gmail.com` and in the `user_registration` the user's email was like `test@edu.cz` (one was missing), so during importing `user_registration` records some user doesn't have mapped epersonId and it causes that the eperson wasn't find by the epersonId in the server and it causes that the license wasn't imported because the user wasn't find by the epersonId.
