### PR TITLE
warning about importing deleted bitstream

### DIFF
--- a/src/pump/_bitstream.py
+++ b/src/pump/_bitstream.py
@@ -232,6 +232,8 @@ class bitstreams:
                 resp = dspace.put_bitstream(params, data)
                 self._id2uuid[str(b_id)] = resp['id']
                 self._imported["bitstream"] += 1
+                if b['deleted']:
+                    logging.warning(f'Imported bitstream is deleted! UUID: {resp["id"]}')
             except Exception as e:
                 _logger.error(f'put_bitstream [{b_id}]: failed. Exception: [{str(e)}]')
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
During Ondrej's bitstream import, two bitstreams were not imported. These bitstreams are deleted and in logs there is not info about importing deleted bitstreams.

## Solution
Added warning about importing of deleted bitstreams to import logs.

## Test
Check if the deleted bitstreams are unvisible. 
**Solution**:  In Ondrej's dump, there are around 145 deleted bitstreams. If an item is deleted, all associated records of this item from other tables are also missing. We cannot find the name of the item, so we cannot check it on Lindat. For the test, we deleted an existing item and checked the records of this item in associated tables. Since we knew the item's name, we could check if we could still find the item or not. We could not see it, which is the desired result.
