### PR TITLE
fetch licenses and import scripts

### DIFF
--- a/src/dspace/_rest.py
+++ b/src/dspace/_rest.py
@@ -243,6 +243,25 @@ class rest:
 
     # =======
 
+    def fetch_licenses(self):
+        url ='core/clarinlicenses'
+        _logger.debug(f"Fatch [] using [{url}]")
+        page = 0
+        licenses = []
+        while True:
+            r = self._fetch(url, self.get, "_embedded",
+                            params={"page": page, "size": 100})
+            if r is None:
+                break
+            key = "clarinlicenses"
+            licenses_data = r.get(key, [])
+            if licenses_data:
+                licenses.extend(licenses_data)
+            else:
+                _logger.warning(f"Key [{key}] does not exist in response: {r}")
+            page += 1
+        return licenses
+
     def put_license_label(self, data: dict):
         url = 'core/clarinlicenselabels'
         _logger.debug(f"Importing [{data}] using [{url}]")

--- a/src/dspace/_rest.py
+++ b/src/dspace/_rest.py
@@ -244,8 +244,8 @@ class rest:
     # =======
 
     def fetch_licenses(self):
-        url ='core/clarinlicenses'
-        _logger.debug(f"Fatch [] using [{url}]")
+        url = 'core/clarinlicenses'
+        _logger.debug(f"Fetch [] using [{url}]")
         page = 0
         licenses = []
         while True:

--- a/src/pump/_license.py
+++ b/src/pump/_license.py
@@ -1,6 +1,7 @@
 import os
 import logging
-from ._utils import read_json, time_method, serialize, deserialize, progress_bar, log_before_import, log_after_import
+
+from pump._utils import read_json, time_method, serialize, deserialize, progress_bar, log_before_import, log_after_import
 
 _logger = logging.getLogger("pump.license")
 
@@ -68,7 +69,7 @@ class licenses:
     def imported_licenses(self):
         return self._imported['licenses']
 
-    def import_to(self, env, dspace, epersons):
+    def import_to(self, env, dspace, epersons = None):
         self._import_license_labels(env, dspace)
         self._import_license_defs(env, dspace, epersons)
 
@@ -143,7 +144,9 @@ class licenses:
             if lic_id in self._license2label:
                 data['extendedClarinLicenseLabels'] = self._license2label[lic_id]
 
-            params = {'eperson': epersons.uuid(lic['eperson_id'])}
+            params = {}
+            if epersons:
+                params = {'eperson': epersons.uuid(lic['eperson_id'])}
             try:
                 resp = dspace.put_license(params, data)
                 self._imported["licenses"] += 1

--- a/src/pump/_license.py
+++ b/src/pump/_license.py
@@ -1,6 +1,5 @@
 import os
 import logging
-
 from pump._utils import read_json, time_method, serialize, deserialize, progress_bar, log_before_import, log_after_import
 
 _logger = logging.getLogger("pump.license")
@@ -69,7 +68,7 @@ class licenses:
     def imported_licenses(self):
         return self._imported['licenses']
 
-    def import_to(self, env, dspace, epersons = None):
+    def import_to(self, env, dspace, epersons=None):
         self._import_license_labels(env, dspace)
         self._import_license_defs(env, dspace, epersons)
 

--- a/tools/license/README.md
+++ b/tools/license/README.md
@@ -3,7 +3,7 @@
 This script retrieves all licenses, labels, and mappings from DSpace that meet the defined conditions and returns them in JSON format.
 
 ```
-python ferch_licenses.py --no_definition dev-5.pc:85 --output data
+python fetch_licenses.py --no_definition dev-5.pc:85 --output data
 ```
 
 # import_licenses.py

--- a/tools/license/README.md
+++ b/tools/license/README.md
@@ -1,0 +1,15 @@
+# fetch_licenses.py
+
+This script retrieves all licenses, labels, and mappings from DSpace that meet the defined conditions and returns them in JSON format.
+
+```
+python ferch_licenses.py --no_definition dev-5.pc:85 --output data
+```
+
+# import_licenses.py
+
+This script imports licenses, labels, and mappings.
+
+```
+python import_licenses.py --input data
+```

--- a/tools/license/fetch_licenses.py
+++ b/tools/license/fetch_licenses.py
@@ -28,32 +28,29 @@ init_logging(_logger, env["log_file"])
 class LicenseProcessor:
     """Class to handle DSpace license retrieval, filtering, and output."""
 
-    def __init__(self, dspace_backend, no_definition, output_dir):
+    def __init__(self, dspace_backend, no_definition):
         """
         Initialize LicenseProcessor with the DSpace backend and settings.
 
         :param dspace_backend: The DSpace backend instance for fetching data.
         :param no_definition: List of strings that cannot be part of the license definition.
-        :param output_dir: The directory to save the output JSON files.
         """
-        self.dspace_backend = dspace_backend
-        self.no_definition = set(no_definition)
-        self.output_dir = output_dir
+        self._dspace_ba = dspace_backend
+        self._no_definition = set(no_definition)
 
-    def fetch_licenses(self, dspace_be):
+    def fetch_licenses(self):
         """Fetch licenses from DSpace backend."""
-        all_licenses = dspace_be.fetch_licenses()
+        all_licenses = self._dspace_be.fetch_licenses()
         _logger.info(f"Number of fetched licenses: {len(all_licenses)}")
         return all_licenses
 
-    def filter_licenses(self, all_licenses, no_definition):
+    def filter_licenses(self, all_licenses):
         """Filter licenses based on the no_definition criteria."""
         key = "definition"
-        no_definition_set = set(no_definition)
         return [
             License(license)
             for license in all_licenses
-            if key in license and not any(arg in license[key] for arg in no_definition_set)
+            if key in license and not any(arg in license[key] for arg in self._no_definition)
         ]
 
     def collect_license_labels(self, filtered_licenses):
@@ -112,11 +109,11 @@ if __name__ == '__main__':
     )
 
     # Create LicenseProcessor instance and process the licenses
-    processor = LicenseProcessor(dspace_be, args.no_definition, args.output)
+    processor = LicenseProcessor(dspace_be, args.no_definition)
 
     # Fetch and filter licenses
-    all_licenses = processor.fetch_licenses(dspace_be)
-    filtered_licenses = processor.filter_licenses(all_licenses, args.no_definition)
+    all_licenses = processor.fetch_licenses()
+    filtered_licenses = processor.filter_licenses(all_licenses)
 
     # Collect unique license labels and extended mappings
     filtered_license_labels = processor.collect_license_labels(filtered_licenses)

--- a/tools/license/fetch_licenses.py
+++ b/tools/license/fetch_licenses.py
@@ -1,0 +1,108 @@
+###
+# This script retrieves all licenses, labels, and mappings from DSpace that meet the defined conditions and returns them in JSON format.
+###
+
+import argparse
+import logging
+import os
+import json
+import sys
+
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+path_to_dspace_lib = os.path.join(_this_dir, "../../libs/dspace-rest-python")
+sys.path.insert(0, os.path.join(_this_dir, "../../src"))
+
+import dspace  # noqa
+import settings  # noqa
+import project_settings  # noqa
+from dspace_rest_client.models import License  # noqa
+from utils import init_logging, update_settings  # noqa
+
+_logger = logging.getLogger()
+
+# env settings, update with project_settings
+env = update_settings(settings.env, project_settings.settings)
+init_logging(_logger, env["log_file"])
+
+
+def fetch_licenses(dspace_be):
+    """Fetch licenses from DSpace backend."""
+    all_licenses = dspace_be.fetch_licenses()
+    _logger.info(f"Number of fetched licenses: {len(all_licenses)}")
+    return all_licenses
+
+
+def filter_licenses(all_licenses, no_definition):
+    """Filter licenses based on the no_definition criteria."""
+    key = "definition"
+    no_definition_set = set(no_definition)
+    return [
+        License(license)
+        for license in all_licenses
+        if key in license and not any(arg in license[key] for arg in no_definition_set)
+    ]
+
+def write_data_to_file(data, output_path):
+    """Write the filtered data to a JSON file."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)  # Ensure output directory exists
+    with open(output_path, 'w', encoding='utf-8') as fout:
+        json.dump(data, fout, indent=2)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Get DSpace licenses that meet condition.")
+    parser.add_argument("--no_definition", type=str, nargs='+', required=True,
+                        help="String that cannot be part of the license definition")
+    parser.add_argument('--output', type=str,
+                        default=os.path.join(_this_dir, "data"),
+                        help='Output directory for the JSON file')
+    args = parser.parse_args()
+
+    # Initialize DSpace backend
+    dspace_be = dspace.rest(
+        env["backend"]["endpoint"],
+        env["backend"]["user"],
+        env["backend"]["password"],
+        env["backend"]["authentication"]
+    )
+
+    # Fetch and filter licenses
+    all_licenses = fetch_licenses(dspace_be)
+    filtered_licenses = filter_licenses(all_licenses, args.no_definition)
+    # Collect unique license labels and extended license mappings
+    added_ids = set()
+    filtered_license_labels = []
+
+    for license in filtered_licenses:
+        # Function to add labels if they're unique
+        def add_unique_label(label):
+            if label and label.id not in added_ids:
+                added_ids.add(label.id)
+                filtered_license_labels.append(label)
+
+        # Add the primary license label
+        add_unique_label(license.licenseLabel)
+
+        # Add extended license labels
+        for ext in license.extendedLicenseLabel or []:
+            add_unique_label(ext)
+
+    # Create extended license mappings
+    filtered_ext_mapping = [
+        {'license_id': license.id, 'label_id': ext.id}
+        for license in filtered_licenses
+        for ext in license.extendedLicenseLabel or []
+    ]
+
+    _logger.info(f"Filtered licenses: {filtered_licenses}")
+    _logger.info(f"Filtered license labels: {filtered_license_labels}")
+    _logger.info(f"Filtered license extended mapping: {filtered_ext_mapping}")
+
+    _logger.info(f"Number of filtered licenses: {len(filtered_licenses)}")
+    _logger.info(f"Number of filtered license labels: {len(filtered_license_labels)}")
+    _logger.info(f"Number of filtered license extended mapping: {len(filtered_ext_mapping)}")
+
+    # Write the filtered data to the specified output file
+    write_data_to_file([license.to_dict() for license in filtered_licenses], os.path.join(args.output, 'licenses.json'))
+    write_data_to_file([license.to_dict() for license in filtered_license_labels], os.path.join(args.output, 'labels.json'))
+    write_data_to_file(filtered_ext_mapping, os.path.join(args.output, 'mapping.json'))

--- a/tools/license/fetch_licenses.py
+++ b/tools/license/fetch_licenses.py
@@ -25,30 +25,72 @@ env = update_settings(settings.env, project_settings.settings)
 init_logging(_logger, env["log_file"])
 
 
-def fetch_licenses(dspace_be):
-    """Fetch licenses from DSpace backend."""
-    all_licenses = dspace_be.fetch_licenses()
-    _logger.info(f"Number of fetched licenses: {len(all_licenses)}")
-    return all_licenses
+class LicenseProcessor:
+    """Class to handle DSpace license retrieval, filtering, and output."""
 
+    def __init__(self, dspace_backend, no_definition, output_dir):
+        """
+        Initialize LicenseProcessor with the DSpace backend and settings.
 
-def filter_licenses(all_licenses, no_definition):
-    """Filter licenses based on the no_definition criteria."""
-    key = "definition"
-    no_definition_set = set(no_definition)
-    return [
-        License(license)
-        for license in all_licenses
-        if key in license and not any(arg in license[key] for arg in no_definition_set)
-    ]
+        :param dspace_backend: The DSpace backend instance for fetching data.
+        :param no_definition: List of strings that cannot be part of the license definition.
+        :param output_dir: The directory to save the output JSON files.
+        """
+        self.dspace_backend = dspace_backend
+        self.no_definition = set(no_definition)
+        self.output_dir = output_dir
 
+    def fetch_licenses(self, dspace_be):
+        """Fetch licenses from DSpace backend."""
+        all_licenses = dspace_be.fetch_licenses()
+        _logger.info(f"Number of fetched licenses: {len(all_licenses)}")
+        return all_licenses
 
-def write_data_to_file(data, output_path):
-    """Write the filtered data to a JSON file."""
-    os.makedirs(os.path.dirname(output_path),
-                exist_ok=True)  # Ensure output directory exists
-    with open(output_path, 'w', encoding='utf-8') as fout:
-        json.dump(data, fout, indent=2)
+    def filter_licenses(self, all_licenses, no_definition):
+        """Filter licenses based on the no_definition criteria."""
+        key = "definition"
+        no_definition_set = set(no_definition)
+        return [
+            License(license)
+            for license in all_licenses
+            if key in license and not any(arg in license[key] for arg in no_definition_set)
+        ]
+
+    def collect_license_labels(self, filtered_licenses):
+        """Collect unique license labels and extended license mappings."""
+        added_ids = set()
+        filtered_license_labels = []
+
+        for license in filtered_licenses:
+            # Function to add labels if they're unique
+            def add_unique_label(label):
+                if label and label.id not in added_ids:
+                    added_ids.add(label.id)
+                    filtered_license_labels.append(label)
+
+            # Add the primary license label
+            add_unique_label(license.licenseLabel)
+
+            # Add extended license labels
+            for ext in license.extendedLicenseLabel or []:
+                add_unique_label(ext)
+
+        return filtered_license_labels
+
+    def create_license_mapping(self, filtered_licenses):
+        """Create extended license mappings."""
+        return [
+            {'license_id': license.id, 'label_id': ext.id}
+            for license in filtered_licenses
+            for ext in license.extendedLicenseLabel or []
+        ]
+
+    def write_data_to_file(self, data: list, output_path: str):
+        """Write the filtered data to a JSON file."""
+        os.makedirs(os.path.dirname(output_path),
+                    exist_ok=True)  # Ensure output directory exists
+        with open(output_path, 'w', encoding='utf-8') as fout:
+            json.dump(data, fout, indent=2, sort_keys=True)
 
 
 if __name__ == '__main__':
@@ -69,34 +111,18 @@ if __name__ == '__main__':
         env["backend"]["authentication"]
     )
 
+    # Create LicenseProcessor instance and process the licenses
+    processor = LicenseProcessor(dspace_be, args.no_definition, args.output)
+
     # Fetch and filter licenses
-    all_licenses = fetch_licenses(dspace_be)
-    filtered_licenses = filter_licenses(all_licenses, args.no_definition)
-    # Collect unique license labels and extended license mappings
-    added_ids = set()
-    filtered_license_labels = []
+    all_licenses = processor.fetch_licenses(dspace_be)
+    filtered_licenses = processor.filter_licenses(all_licenses, args.no_definition)
 
-    for license in filtered_licenses:
-        # Function to add labels if they're unique
-        def add_unique_label(label):
-            if label and label.id not in added_ids:
-                added_ids.add(label.id)
-                filtered_license_labels.append(label)
+    # Collect unique license labels and extended mappings
+    filtered_license_labels = processor.collect_license_labels(filtered_licenses)
+    filtered_ext_mapping = processor.create_license_mapping(filtered_licenses)
 
-        # Add the primary license label
-        add_unique_label(license.licenseLabel)
-
-        # Add extended license labels
-        for ext in license.extendedLicenseLabel or []:
-            add_unique_label(ext)
-
-    # Create extended license mappings
-    filtered_ext_mapping = [
-        {'license_id': license.id, 'label_id': ext.id}
-        for license in filtered_licenses
-        for ext in license.extendedLicenseLabel or []
-    ]
-
+    # Log filtered results
     _logger.info(f"Filtered licenses: {filtered_licenses}")
     _logger.info(f"Filtered license labels: {filtered_license_labels}")
     _logger.info(f"Filtered license extended mapping: {filtered_ext_mapping}")
@@ -107,8 +133,9 @@ if __name__ == '__main__':
         f"Number of filtered license extended mapping: {len(filtered_ext_mapping)}")
 
     # Write the filtered data to the specified output file
-    write_data_to_file([license.to_dict() for license in filtered_licenses],
-                       os.path.join(args.output, 'licenses.json'))
-    write_data_to_file([license.to_dict() for license in filtered_license_labels],
-                       os.path.join(args.output, 'labels.json'))
-    write_data_to_file(filtered_ext_mapping, os.path.join(args.output, 'mapping.json'))
+    processor.write_data_to_file([license.to_dict() for license in filtered_licenses],
+                                 os.path.join(args.output, 'licenses.json'))
+    processor.write_data_to_file([license.to_dict() for license in filtered_license_labels],
+                                 os.path.join(args.output, 'labels.json'))
+    processor.write_data_to_file(
+        filtered_ext_mapping, os.path.join(args.output, 'mapping.json'))

--- a/tools/license/fetch_licenses.py
+++ b/tools/license/fetch_licenses.py
@@ -42,15 +42,18 @@ def filter_licenses(all_licenses, no_definition):
         if key in license and not any(arg in license[key] for arg in no_definition_set)
     ]
 
+
 def write_data_to_file(data, output_path):
     """Write the filtered data to a JSON file."""
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)  # Ensure output directory exists
+    os.makedirs(os.path.dirname(output_path),
+                exist_ok=True)  # Ensure output directory exists
     with open(output_path, 'w', encoding='utf-8') as fout:
         json.dump(data, fout, indent=2)
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Get DSpace licenses that meet condition.")
+    parser = argparse.ArgumentParser(
+        description="Get DSpace licenses that meet condition.")
     parser.add_argument("--no_definition", type=str, nargs='+', required=True,
                         help="String that cannot be part of the license definition")
     parser.add_argument('--output', type=str,
@@ -100,9 +103,12 @@ if __name__ == '__main__':
 
     _logger.info(f"Number of filtered licenses: {len(filtered_licenses)}")
     _logger.info(f"Number of filtered license labels: {len(filtered_license_labels)}")
-    _logger.info(f"Number of filtered license extended mapping: {len(filtered_ext_mapping)}")
+    _logger.info(
+        f"Number of filtered license extended mapping: {len(filtered_ext_mapping)}")
 
     # Write the filtered data to the specified output file
-    write_data_to_file([license.to_dict() for license in filtered_licenses], os.path.join(args.output, 'licenses.json'))
-    write_data_to_file([license.to_dict() for license in filtered_license_labels], os.path.join(args.output, 'labels.json'))
+    write_data_to_file([license.to_dict() for license in filtered_licenses],
+                       os.path.join(args.output, 'licenses.json'))
+    write_data_to_file([license.to_dict() for license in filtered_license_labels],
+                       os.path.join(args.output, 'labels.json'))
     write_data_to_file(filtered_ext_mapping, os.path.join(args.output, 'mapping.json'))

--- a/tools/license/import_licenses.py
+++ b/tools/license/import_licenses.py
@@ -1,0 +1,51 @@
+###
+# This script import license, labels and mappings.
+###
+import argparse
+import logging
+import os
+import sys
+
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+path_to_dspace_lib = os.path.join(_this_dir, "../../libs/dspace-rest-python")
+sys.path.insert(0, os.path.join(_this_dir, "../../src"))
+sys.path.insert(0, os.path.join(_this_dir, "../../src/pump"))
+
+import dspace  # noqa
+import pump  # noqa
+import settings  # noqa
+import project_settings  # noqa
+from dspace_rest_client.models import License  # noqa
+from utils import init_logging, update_settings  # noqa
+
+from _license import licenses
+
+_logger = logging.getLogger()
+
+# env settings, update with project_settings
+env = update_settings(settings.env, project_settings.settings)
+init_logging(_logger, env["log_file"])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Import licenses to DSpace.")
+    parser.add_argument('--input', type=str,
+                        default=os.path.join(_this_dir, "data"),
+                        help='Input directory for the JSON file')
+    args = parser.parse_args()
+
+    # Initialize DSpace backend
+    dspace_be = dspace.rest(
+        env["backend"]["endpoint"],
+        env["backend"]["user"],
+        env["backend"]["password"],
+        env["backend"]["authentication"]
+    )
+
+    _logger.info("Loading license import")
+    licenses_imp = licenses(os.path.join(args.input, 'labels.json'), os.path.join(args.input, 'licenses.json'), os.path.join(args.input, 'mapping.json'))
+
+    # import licenses
+    _logger.info("Start license import")
+    licenses_imp.import_to(env, dspace_be)
+    _logger.info("End license import")

--- a/tools/license/import_licenses.py
+++ b/tools/license/import_licenses.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
     )
 
     _logger.info("Loading license import")
-    licenses_imp = licenses(os.path.join(args.input, 'labels.json'), os.path.join(args.input, 'licenses.json'), os.path.join(args.input, 'mapping.json'))
+    licenses_imp = licenses(os.path.join(args.input, 'labels.json'), os.path.join(
+        args.input, 'licenses.json'), os.path.join(args.input, 'mapping.json'))
 
     # import licenses
     _logger.info("Start license import")


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  6  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
After the vanilla import, the tables containing licenses are empty because there were no licenses beforehand.

## Analysis
Fetch licenses, labels, and extended mappings from the database where licenses already exist. Filter them based on the definitions that are not required, and import them into vanilla DSpace where they are missing.