### PR TITLE
pump/ignore-mtd-for-bitstream

### DIFF
--- a/src/pump/_bitstream.py
+++ b/src/pump/_bitstream.py
@@ -24,6 +24,8 @@ class bitstreams:
 
     ]
 
+    ignored_fields = ["local.bitstream.redirectToURL"]
+
     def __init__(self, bitstream_file_str: str, bundle2bitstream_file_str: str):
         self._bs = read_json(bitstream_file_str)
         self._bundle2bs = read_json(bundle2bitstream_file_str)
@@ -168,8 +170,8 @@ class bitstreams:
                     _logger.error(f'add_checksums failed: [{str(e)}]')
 
             data = {}
-            b_meta = metadatas.value(bitstreams.TYPE, b_id,
-                                     log_missing=b_deleted is False)
+            b_meta = metadatas.filter_res_d(metadatas.value(
+                bitstreams.TYPE, b_id, log_missing=b_deleted is False), self.ignored_fields)
             if b_meta is not None:
                 data['metadata'] = b_meta
             else:

--- a/src/pump/_item.py
+++ b/src/pump/_item.py
@@ -31,8 +31,6 @@ class items:
         }],
     ]
 
-    ignored_fields = ["local.bitstream.redirectToURL"]
-
     def __init__(self,
                  item_file_str: str,
                  ws_file_str: str,
@@ -159,8 +157,8 @@ class items:
             'lastModified': item['last_modified'],
             'withdrawn': item['withdrawn']
         }
-        i_meta = metadatas.filter_res_d(metadatas.value(
-            items.TYPE, i_id, None, True), self.ignored_fields)
+        i_meta = metadatas.value(
+            items.TYPE, i_id, None, True)
         if i_meta is not None:
             data['metadata'] = i_meta
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  1  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.4  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The task was to ignore the metadata field `local.bitstream.redirectToUrl` during import. We ignore this metadata for the item, but it is part of the bitstream metadata.
**Solution:**
Ignore this metadata during bitstream import.
