### PR TITLE
pump/replace-mtd-field

### DIFF
--- a/src/pump/_item.py
+++ b/src/pump/_item.py
@@ -31,7 +31,7 @@ class items:
         }],
     ]
 
-    ignored_fields = ["local.bitstream.redirectToURL"]
+    replaced_fields = {'local.hasMetadata': 'local.hasCMDI'}
 
     def __init__(self,
                  item_file_str: str,
@@ -159,8 +159,8 @@ class items:
             'lastModified': item['last_modified'],
             'withdrawn': item['withdrawn']
         }
-        i_meta = metadatas.filter_res_d(metadatas.value(
-            items.TYPE, i_id, None, True), self.ignored_fields)
+        i_meta = metadatas.replace_meta_val(metadatas.value(
+            items.TYPE, i_id, None, True), self.replaced_fields)
         if i_meta is not None:
             data['metadata'] = i_meta
 

--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -542,6 +542,12 @@ class metadatas:
         """
         return {key: val for key, val in (res_d or {}).items() if key not in ignored_mtd_fields}
 
+    def replace_meta_val(self, res_d, replace_d):
+        """
+        Replace the mtd field in res_d with corresponding values from replace_d if the key exists in replace_d.
+        """
+        return {key: replace_d.get(key, val) for key, val in (res_d or {}).items()}
+
     def value(self, res_type_id: int, res_id: int, text_for_field_id: int = None, log_missing: bool = True):
         """
             Get metadata value for dspace object.


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0.5  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.45  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In v5, there is a metadata field named `local.hasMetadata`. In v7, the name of this field is `local.hasCMDI`.
**Solution:**
Replace the name of the metadata field during item import.

