### PR TITLE
test for ignored emtadata fields

### DIFF
--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -147,6 +147,21 @@ class metadatas:
         }],
     ]
 
+    test_table = [
+        {
+            "name": "ignored_redirectToURL",
+            "left": ["sql", "db7", "one", "select count(*) from metadatafieldregistry "
+                                          "where qualifier = 'redirectToURL'"],
+            "right": ["val", 0]
+        },
+        {
+            "name": "ignored_hasMetadata",
+            "left": ["sql", "db7", "one", "select count(*) from metadatafieldregistry "
+                                          "where element = 'hasMetadata'"],
+            "right": ["val", 0]
+        }
+    ]
+
     def __init__(self, env, dspace, value_file_str: str, field_file_str: str, schema_file_str: str):
         self._dspace = dspace
         self._values = {}


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Added test if ignored metadata fields from v5 are not in database after import.