### PR TITLE
added to ignored metadata_fields for import

### DIFF
--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -122,12 +122,18 @@ class metadatas:
             delete from metadatavalue ; delete from metadatafieldregistry ; delete from metadataschemaregistry ;
     """
 
+    # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=98 ;
+    #  metadata_field_id | metadata_schema_id |   element   |   qualifier   |               scope_note
+    # -------------------+--------------------+-------------+---------------+----------------------------------------
+    #                 98 |                  3 | hasMetadata |     null      |      Indicates uploaded cmdi file
     # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=176 ;
-    #  metadata_field_id | metadata_schema_id |  element  | qualifier |               scope_note
-    # -------------------+--------------------+-----------+-----------+----------------------------------------
-    #                176 |                  3 | bitstream | file      | Files inside a bitstream if an archive
+    # -------------------+--------------------+-------------+---------------+----------------------------------------
+    #                176 |                  3 |  bitstream  |     file      | Files inside a bitstream if an archive
+    # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=178 ;
+    # -------------------+--------------------+-------------+---------------+----------------------------------------
+    #                178 |                  3 |  bitstream  | redirectToURL |    Get the bitstream from this URL.
     IGNORE_FIELDS = [
-        176
+        98, 176, 178
     ]
 
     validate_table = [


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
We need to ignored two metadata fields with id 98 and 178 in v5.
