### PR TITLE
remove hasMetadata from ignored fields

### DIFF
--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -122,7 +122,7 @@ class metadatas:
             delete from metadatavalue ; delete from metadatafieldregistry ; delete from metadataschemaregistry ;
     """
 
-    # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=98 ;
+    # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=176 ;
     #  metadata_field_id | metadata_schema_id |   element   |   qualifier   |               scope_note
     # -------------------+--------------------+-------------+---------------+----------------------------------------
     #                176 |                  3 |  bitstream  |     file      | Files inside a bitstream if an archive

--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -125,15 +125,12 @@ class metadatas:
     # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=98 ;
     #  metadata_field_id | metadata_schema_id |   element   |   qualifier   |               scope_note
     # -------------------+--------------------+-------------+---------------+----------------------------------------
-    #                 98 |                  3 | hasMetadata |     null      |      Indicates uploaded cmdi file
-    # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=176 ;
-    # -------------------+--------------------+-------------+---------------+----------------------------------------
     #                176 |                  3 |  bitstream  |     file      | Files inside a bitstream if an archive
     # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=178 ;
     # -------------------+--------------------+-------------+---------------+----------------------------------------
     #                178 |                  3 |  bitstream  | redirectToURL |    Get the bitstream from this URL.
     IGNORE_FIELDS = [
-        98, 176, 178
+        176, 178
     ]
 
     validate_table = [


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
After the import, metadata of type hasMetadata was not replaced by hasCMDI. The hasCMDI metadata does not exist. This happened because we didn’t want to import the metadata field hasMetadata, so we added it to IGNORE_METADATA. However, this did not ignore only import to metadata field — it ignored all metadata. As a result, we ended up importing nothing.
Now, the hasMetadata will be in the metadata field table, but only because it was added after the forced database migration in DSpace.