### PR TITLE
Use different file from the assetstore because the previous one was corrupted

### DIFF
--- a/src/pump/_bitstream.py
+++ b/src/pump/_bitstream.py
@@ -228,9 +228,9 @@ class bitstreams:
                 data['sizeBytes'] = 1748
                 data['checkSum'] = {
                     'checkSumAlgorithm': b['checksum_algorithm'],
-                    'value': '8a4605be74aa9ea9d79846c1fba20a33'
+                    'value': 'bb9bdc0b3349e4284e09149f943790b4'
                 }
-                params['internal_id'] = '77893754617268908529226218097860272513'
+                params['internal_id'] = '57024294293009067626820405177604023574'
 
             # if bitstream has bundle, set bundle_id from None to id
             if b_id in self._bs2bundle:


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The checksum of the previous file didn't match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Made internal adjustments to improve consistency when handling specific testing scenarios.  
	- No visible changes are expected for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->