### PR TITLE
UFAL/Import dead and deadSince to external handle

### DIFF
--- a/src/dspace/_rest.py
+++ b/src/dspace/_rest.py
@@ -87,13 +87,15 @@ class rest:
             Mapped table: handles
         """
         url = 'clarin/import/handle'
-        arr = [{'handle': h['handle'], 'resourceTypeID': h['resource_type_id']}
+        arr = [{'handle': h['handle'], 'resourceTypeID': h['resource_type_id'],
+                'dead': h['dead'], 'deadSince': h['dead_since']}
                for h in handle_arr]
         return self._put(url, arr)
 
     def put_handles(self, handle_arr: list):
         url = 'core/handles'
-        arr = [{'handle': h['handle'], 'url': h['url']} for h in handle_arr]
+        arr = [{'handle': h['handle'], 'url': h['url'], 'dead': h['dead'],
+                'deadSince': h['dead_since']} for h in handle_arr]
         return self._put(url, arr)
 
     # =======


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The handle attributes dead and deadSince were not imported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced handle management by including additional status fields for each handle.
- **Bug Fixes**
  - Improved accuracy of handle status updates with new data fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->