### PR TITLE
Removed hardcoded db names

### DIFF
--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -405,8 +405,13 @@ class differ:
         for valid_defs in to_validate:
             for table_name, defin in valid_defs:
                 _logger.info("=" * 10 + f" Validating {table_name} " + "=" * 10)
-                db5_name = defin.get("db", "clarin-dspace")
-                db5 = self.raw_db_dspace_5 if db5_name == "clarin-dspace" else self.raw_db_utilities_5
+                raw_db_name = getattr(
+                    getattr(self.raw_db_dspace_5, "_conn", None),
+                    "name",
+                    None
+                )
+                db5_name = defin.get("db", raw_db_name)
+                db5 = self.raw_db_dspace_5 if db5_name == raw_db_name else self.raw_db_utilities_5
 
                 cmp = defin.get("compare", None)
                 if cmp is not None:

--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import logging
-from _utils import allowed_db
 _logger = logging.getLogger("pump.db")
 
 
@@ -407,8 +406,8 @@ class differ:
             for table_name, defin in valid_defs:
                 _logger.info("=" * 10 + f" Validating {table_name} " + "=" * 10)
 
-                db5_name = defin.get("db", allowed_db.DSPACE)
-                db5 = self.raw_db_dspace_5 if db5_name == allowed_db.DSPACE else self.raw_db_utilities_5
+                db5_name = defin.get("db", "db_dspace_5")
+                db5 = self.raw_db_dspace_5 if db5_name == "db_dspace_5" else self.raw_db_utilities_5
 
                 cmp = defin.get("compare", None)
                 if cmp is not None:

--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import logging
+from _utils import allowed_db
 _logger = logging.getLogger("pump.db")
 
 
@@ -405,13 +406,9 @@ class differ:
         for valid_defs in to_validate:
             for table_name, defin in valid_defs:
                 _logger.info("=" * 10 + f" Validating {table_name} " + "=" * 10)
-                raw_db_name = getattr(
-                    getattr(self.raw_db_dspace_5, "_conn", None),
-                    "name",
-                    "clarin-dspace"
-                )
-                db5_name = defin.get("db", raw_db_name)
-                db5 = self.raw_db_dspace_5 if db5_name == raw_db_name else self.raw_db_utilities_5
+
+                db5_name = defin.get("db", allowed_db.DSPACE)
+                db5 = self.raw_db_dspace_5 if db5_name == allowed_db.DSPACE else self.raw_db_utilities_5
 
                 cmp = defin.get("compare", None)
                 if cmp is not None:

--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -408,7 +408,7 @@ class differ:
                 raw_db_name = getattr(
                     getattr(self.raw_db_dspace_5, "_conn", None),
                     "name",
-                    None
+                    "clarin-dspace"
                 )
                 db5_name = defin.get("db", raw_db_name)
                 db5 = self.raw_db_dspace_5 if db5_name == raw_db_name else self.raw_db_utilities_5

--- a/src/pump/_license.py
+++ b/src/pump/_license.py
@@ -7,37 +7,11 @@ _logger = logging.getLogger("pump.license")
 
 class licenses:
 
-    validate_table = [
-        ["license_definition", {
-            "compare": ["name", "confirmation", "required_info"],
-            "db": "clarin-utilities",
-        }],
-        ["license_label", {
-            "compare": ["label", "title"],
-            "db": "clarin-utilities",
-        }],
-        ["license_label", {
-            "compare": ["label", "title"],
-            "db": "clarin-utilities",
-        }],
-        ["license_label_extended_mapping", {
-            "nonnull": ["license_id"],
-            "db": "clarin-utilities",
-        }],
-        ["license_resource_user_allowance", {
-            "nonnull": ["mapping_id"],
-            "db": "clarin-utilities",
-        }],
-        ["license_resource_mapping", {
-            "nonnull": ["license_id"],
-            "db": "clarin-utilities",
-        }],
-    ]
-
     def __init__(self,
                  license_labels_file_str: str,
                  license_defs_file_str: str,
-                 license_map_file_str: str):
+                 license_map_file_str: str,
+                 db_name: str):
         self._labels = read_json(license_labels_file_str)
         self._licenses = read_json(license_defs_file_str)
         self._map = read_json(license_map_file_str)
@@ -56,6 +30,33 @@ class licenses:
             _logger.info(f"Empty input: [{license_map_file_str}].")
         if len(self._licenses) == 0:
             _logger.info(f"Empty input: [{license_defs_file_str}].")
+
+        self.validate_table = [
+            ["license_definition", {
+                "compare": ["name", "confirmation", "required_info"],
+                "db": db_name,
+            }],
+            ["license_label", {
+                "compare": ["label", "title"],
+                "db": db_name,
+            }],
+            ["license_label", {
+                "compare": ["label", "title"],
+                "db": db_name,
+            }],
+            ["license_label_extended_mapping", {
+                "nonnull": ["license_id"],
+                "db": db_name,
+            }],
+            ["license_resource_user_allowance", {
+                "nonnull": ["mapping_id"],
+                "db": db_name,
+            }],
+            ["license_resource_mapping", {
+                "nonnull": ["license_id"],
+                "db": db_name,
+            }],
+        ]
 
     def __len__(self):
         return len(self._labels)

--- a/src/pump/_license.py
+++ b/src/pump/_license.py
@@ -1,17 +1,44 @@
 import os
 import logging
-from pump._utils import read_json, time_method, serialize, deserialize, progress_bar, log_before_import, log_after_import
+from pump._utils import (read_json, time_method, serialize, deserialize, progress_bar, log_before_import,
+                         log_after_import, allowed_db)
 
 _logger = logging.getLogger("pump.license")
 
 
 class licenses:
 
+    validate_table = [
+        ["license_definition", {
+            "compare": ["name", "confirmation", "required_info"],
+            "db": allowed_db.DB_UTILITIES,
+        }],
+        ["license_label", {
+            "compare": ["label", "title"],
+            "db": allowed_db.DB_UTILITIES,
+        }],
+        ["license_label", {
+            "compare": ["label", "title"],
+            "db": allowed_db.DB_UTILITIES,
+        }],
+        ["license_label_extended_mapping", {
+            "nonnull": ["license_id"],
+            "db": allowed_db.DB_UTILITIES,
+        }],
+        ["license_resource_user_allowance", {
+            "nonnull": ["mapping_id"],
+            "db": allowed_db.DB_UTILITIES,
+        }],
+        ["license_resource_mapping", {
+            "nonnull": ["license_id"],
+            "db": allowed_db.DB_UTILITIES,
+        }],
+    ]
+
     def __init__(self,
                  license_labels_file_str: str,
                  license_defs_file_str: str,
-                 license_map_file_str: str,
-                 db_name: str):
+                 license_map_file_str: str):
         self._labels = read_json(license_labels_file_str)
         self._licenses = read_json(license_defs_file_str)
         self._map = read_json(license_map_file_str)
@@ -30,33 +57,6 @@ class licenses:
             _logger.info(f"Empty input: [{license_map_file_str}].")
         if len(self._licenses) == 0:
             _logger.info(f"Empty input: [{license_defs_file_str}].")
-
-        self.validate_table = [
-            ["license_definition", {
-                "compare": ["name", "confirmation", "required_info"],
-                "db": db_name,
-            }],
-            ["license_label", {
-                "compare": ["label", "title"],
-                "db": db_name,
-            }],
-            ["license_label", {
-                "compare": ["label", "title"],
-                "db": db_name,
-            }],
-            ["license_label_extended_mapping", {
-                "nonnull": ["license_id"],
-                "db": db_name,
-            }],
-            ["license_resource_user_allowance", {
-                "nonnull": ["mapping_id"],
-                "db": db_name,
-            }],
-            ["license_resource_mapping", {
-                "nonnull": ["license_id"],
-                "db": db_name,
-            }],
-        ]
 
     def __len__(self):
         return len(self._labels)

--- a/src/pump/_license.py
+++ b/src/pump/_license.py
@@ -1,7 +1,6 @@
 import os
 import logging
-from pump._utils import (read_json, time_method, serialize, deserialize, progress_bar, log_before_import,
-                         log_after_import, allowed_db)
+from pump._utils import read_json, time_method, serialize, deserialize, progress_bar, log_before_import, log_after_import
 
 _logger = logging.getLogger("pump.license")
 
@@ -11,27 +10,27 @@ class licenses:
     validate_table = [
         ["license_definition", {
             "compare": ["name", "confirmation", "required_info"],
-            "db": allowed_db.DB_UTILITIES,
+            "db": "db_utilities_5",
         }],
         ["license_label", {
             "compare": ["label", "title"],
-            "db": allowed_db.DB_UTILITIES,
+            "db": "db_utilities_5",
         }],
         ["license_label", {
             "compare": ["label", "title"],
-            "db": allowed_db.DB_UTILITIES,
+            "db": "db_utilities_5",
         }],
         ["license_label_extended_mapping", {
             "nonnull": ["license_id"],
-            "db": allowed_db.DB_UTILITIES,
+            "db": "db_utilities_5",
         }],
         ["license_resource_user_allowance", {
             "nonnull": ["mapping_id"],
-            "db": allowed_db.DB_UTILITIES,
+            "db": "db_utilities_5",
         }],
         ["license_resource_mapping", {
             "nonnull": ["license_id"],
-            "db": allowed_db.DB_UTILITIES,
+            "db": "db_utilities_5",
         }],
     ]
 

--- a/src/pump/_repo.py
+++ b/src/pump/_repo.py
@@ -120,6 +120,7 @@ class repo:
             _f("license_label"),
             _f("license_definition"),
             _f("license_label_extended_mapping"),
+            env.get("db_utilities_5", {}).get("name", "clarin-utilities")
         )
 
         self.items = items(

--- a/src/pump/_repo.py
+++ b/src/pump/_repo.py
@@ -119,8 +119,7 @@ class repo:
         self.licenses = licenses(
             _f("license_label"),
             _f("license_definition"),
-            _f("license_label_extended_mapping"),
-            env.get("db_utilities_5", {}).get("name", "clarin-utilities")
+            _f("license_label_extended_mapping")
         )
 
         self.items = items(

--- a/src/pump/_sequences.py
+++ b/src/pump/_sequences.py
@@ -39,7 +39,7 @@ class sequences:
                 continue
 
             # use cursor according to database to which sequence belongs
-            if dspace5_seq_db == "clarin-dspace":
+            if dspace5_seq_db == env["db_dspace_5"]["name"]:
                 db = db5_dspace
             else:
                 db = db5_utilities

--- a/src/pump/_sequences.py
+++ b/src/pump/_sequences.py
@@ -39,7 +39,7 @@ class sequences:
                 continue
 
             # use cursor according to database to which sequence belongs
-            if dspace5_seq_db == env["db_dspace_5"]["name"]:
+            if dspace5_seq_db == env.get("db_dspace_5", {}).get("name", "clarin-dspace"):
                 db = db5_dspace
             else:
                 db = db5_utilities

--- a/src/pump/_utils.py
+++ b/src/pump/_utils.py
@@ -3,7 +3,6 @@ import os
 import logging
 from datetime import datetime, timezone
 from time import time as time_fnc
-from enum import Enum
 
 
 _logger = logging.getLogger("pump.utils")
@@ -130,8 +129,3 @@ def log_before_import(msg: str, expected: int):
 def log_after_import(msg: str, expected: int, imported: int):
     prefix = "OK " if expected == imported else "!!! WARN !!! "
     _logger.info(f"{prefix}Imported [{imported: >4d}] {msg}")
-
-
-class allowed_db(str, Enum):
-    UTILITIES = "db_utilities_5"
-    DSPACE = "db_dspace_5"

--- a/src/pump/_utils.py
+++ b/src/pump/_utils.py
@@ -3,6 +3,8 @@ import os
 import logging
 from datetime import datetime, timezone
 from time import time as time_fnc
+from enum import Enum
+
 
 _logger = logging.getLogger("pump.utils")
 
@@ -128,3 +130,8 @@ def log_before_import(msg: str, expected: int):
 def log_after_import(msg: str, expected: int, imported: int):
     prefix = "OK " if expected == imported else "!!! WARN !!! "
     _logger.info(f"{prefix}Imported [{imported: >4d}] {msg}")
+
+
+class allowed_db(str, Enum):
+    UTILITIES = "db_utilities_5"
+    DSPACE = "db_dspace_5"


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In dspace-import, there were several places where the database name was hardcoded. Use project settings instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated database name handling to use dynamic values from environment or connection settings instead of hardcoded strings, improving flexibility across multiple components.
  - Adjusted class constructors and attribute initialization to support dynamic database configuration.
- **Chores**
  - Improved internal logic for determining which database instance to use, enhancing maintainability and adaptability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->