### PR TITLE
ufal/incorrect-password-hash-funct-used-during-migration

### DIFF
--- a/src/pump/_eperson.py
+++ b/src/pump/_eperson.py
@@ -97,13 +97,13 @@ class epersons:
                 continue
 
             data = {
-                'requireCertificate': e['require_certificate'],
-                'netid': e['netid'],
-                'canLogIn': e['can_log_in'],
-                'email': e['email'],
+                'requireCertificate': e.get('require_certificate'),
+                'netid': e.get('netid'),
+                'canLogIn': e.get('can_log_in'),
+                'email': e.get('email'),
                 'password': None,
-                'welcomeInfo': e['welcome_info'],
-                'canEditSubmissionMetadata': e['can_edit_submission_metadata']
+                'welcomeInfo': e.get('welcome_info'),
+                'canEditSubmissionMetadata': e.get('can_edit_submission_metadata')
             }
 
             e_meta = metadatas.value(epersons.TYPE, e_id)

--- a/src/pump/_eperson.py
+++ b/src/pump/_eperson.py
@@ -97,13 +97,11 @@ class epersons:
                 continue
 
             data = {
-                'selfRegistered': e['self_registered'],
                 'requireCertificate': e['require_certificate'],
                 'netid': e['netid'],
                 'canLogIn': e['can_log_in'],
-                'lastActive': e['last_active'],
                 'email': e['email'],
-                'password': e['password'],
+                'password': None,
                 'welcomeInfo': e['welcome_info'],
                 'canEditSubmissionMetadata': e['can_edit_submission_metadata']
             }
@@ -113,8 +111,11 @@ class epersons:
                 data['metadata'] = e_meta
 
             params = {
-                'selfRegistered': e['self_registered'],
-                'lastActive': e['last_active']
+                'selfRegistered': e.get('self_registered'),
+                'lastActive': e.get('last_active'),
+                'password': e.get('password'),
+                'salt': e.get('salt'),
+                'digestAlgorithm': e.get('digest_algorithm')
             }
             try:
                 resp = dspace.put_eperson(params, data)


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The password, salt, and digest algorithm are incorrectly imported during migration.
## Solution
Pass them as parameters to avoid rehashing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user authentication fields during import, ensuring password and related parameters are managed more securely and robustly.
  * Enhanced compatibility for user data imports by allowing missing authentication fields without causing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->