### PR TITLE
Independece from metadata field ids

### DIFF
--- a/src/project_settings.py
+++ b/src/project_settings.py
@@ -51,7 +51,8 @@ settings = {
     },
 
     "input": {
-        "tempdbexport": os.path.join(_this_dir, "../input/tempdbexport"),
+        "tempdbexport_v5": os.path.join(_this_dir, "../input/tempdbexport_v5"),
+        "tempdbexport_v7": os.path.join(_this_dir, "../input/tempdbexport_v7"),
         "icondir": os.path.join(_this_dir, "../input/icon"),
     },
 

--- a/src/project_settings.py
+++ b/src/project_settings.py
@@ -29,16 +29,16 @@ settings = {
         # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=178 ;
         # -------------------+--------------------+-------------+---------------+----------------------------------------
         #                178 |                  3 |  bitstream  | redirectToURL |    Get the bitstream from this URL.
-        "fields": [176, 178]
+        "fields": ['local.bitstream.file', 'local.bitstream.redirectToURL'],
     },
 
-    "replace": {
+    "replaced": {
         # fields which will be replaced in metadata
         # if we want to ignore the metadata field, we must replace field when metadata is imported!
         #  metadata_field_id | metadata_schema_id |   element   |   qualifier   |               scope_note
         # -------------------+--------------------+-------------+---------------+----------------------------------------
         #                98  |                  3 | hasMetadata |     null      |       Indicates uploaded cmdi file
-        "fields": [98]
+        "fields": ['local.hasMetadata'],
     },
 
     "db_dspace_7": {

--- a/src/project_settings.py
+++ b/src/project_settings.py
@@ -22,6 +22,23 @@ settings = {
             # ignore - empty person
             198
         ],
+        # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=176 ;
+        #  metadata_field_id | metadata_schema_id |   element   |   qualifier   |               scope_note
+        # -------------------+--------------------+-------------+---------------+----------------------------------------
+        #                176 |                  3 |  bitstream  |     file      | Files inside a bitstream if an archive
+        # clarin-dspace=# select * from metadatafieldregistry  where metadata_field_id=178 ;
+        # -------------------+--------------------+-------------+---------------+----------------------------------------
+        #                178 |                  3 |  bitstream  | redirectToURL |    Get the bitstream from this URL.
+        "fields": [176, 178]
+    },
+
+    "replace": {
+        # fields which will be replaced in metadata
+        # if we want to ignore the metadata field, we must replace field when metadata is imported!
+        #  metadata_field_id | metadata_schema_id |   element   |   qualifier   |               scope_note
+        # -------------------+--------------------+-------------+---------------+----------------------------------------
+        #                98  |                  3 | hasMetadata |     null      |       Indicates uploaded cmdi file
+        "fields": [98]
     },
 
     "db_dspace_7": {

--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -289,42 +289,42 @@ class metadatas:
     def V7_FIELD_ID_LIC(self):
         from_map = self.get_existed_field_by_name_v7('dc.rights.uri')
         if from_map is None:
-            raise ValueError("Field ID for 'rights.uri' in v7 not found.")
+            raise ValueError("Field ID for 'dc.rights.uri' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_DATE_ISSUED(self):
         from_map = self.get_existed_field_by_name_v7('dc.date.issued')
         if from_map is None:
-            raise ValueError("Field ID for 'date.issued' in v7 not found.")
+            raise ValueError("Field ID for 'dc.date.issued' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_LANG_ADDED(self):
         from_map = self.get_existed_field_by_name_v7('local.language.name')
         if from_map is None:
-            raise ValueError("Field ID for 'language.name' in v7 not found.")
+            raise ValueError("Field ID for 'local.language.name' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_IDENTIFIER_URI(self):
         from_map = self.get_existed_field_by_name_v7('dc.identifier.uri')
         if from_map is None:
-            raise ValueError("Field ID for 'identifier.uri' in v7 not found.")
+            raise ValueError("Field ID for 'dc.identifier.uri' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_TITLE(self):
         from_map = self.get_existed_field_by_name_v7('dc.title.None')
         if from_map is None:
-            raise ValueError("Field ID for 'title.None' in v7 not found.")
+            raise ValueError("Field ID for 'dc.title.None' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_PROVENANCE(self):
         from_map = self.get_existed_field_by_name_v7('dc.description.provenance')
         if from_map is None:
-            raise ValueError("Field ID for 'description.provenance' in v7 not found.")
+            raise ValueError("Field ID for 'dc.description.provenance' in v7 not found.")
         return from_map
 
     @property
@@ -382,7 +382,6 @@ class metadatas:
             "imported": self._imported,
             "v5_fields_name2id": self._v5_fields_name2id,
             "v7_fields_name2id": self._v7_fields_name2id,
-            "field_v7_existed": self._field_v7_existed,
         }
         serialize(file_str, data)
 
@@ -393,7 +392,6 @@ class metadatas:
         self._imported = data["imported"]
         self._v5_fields_name2id = data["v5_fields_name2id"]
         self._v7_fields_name2id = data["v7_fields_name2id"]
-        self._field_v7_existed = data["field_v7_existed"]
 
     # =============
 

--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -257,9 +257,10 @@ class metadatas:
         Prepares the field name for lookup in v5 or v7 dictionaries.
 
         Rules:
-        - If name contains more than one dot ('.'), return None (invalid).
+        - If name contains more than two dots ('.'), return None (invalid).
+        - If name contains less than one dot, return None (invalid).
         - If name contains exactly one dot, append '.None' suffix.
-        - If name contains no dot, return None (invalid).
+        - Otherwise, return name as is.
         """
         dot_count = name.count('.')
         if dot_count > 2 or dot_count < 1:

--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -257,64 +257,71 @@ class metadatas:
     @property
     def V5_DC_RELATION_REPLACES_ID(self):
         from_map = self.get_field_id_by_name_v5('relation.replaces')
-        assert 50 == from_map
+        if from_map is None:
+            raise ValueError("Field ID for 'relation.replaces' in v5 not found.")
         return from_map
 
     @property
     def V5_DC_RELATION_ISREPLACEDBY_ID(self):
         from_map = self.get_field_id_by_name_v5('relation.isreplacedby')
-        assert 51 == from_map
+        if from_map is None:
+            raise ValueError("Field ID for 'relation.isreplacedby' in v5 not found.")
         return from_map
 
     @property
     def V5_DC_IDENTIFIER_URI_ID(self):
         from_map = self.get_field_id_by_name_v5('identifier.uri')
-        assert 25 == from_map
+        if from_map is None:
+            raise ValueError("Field ID for 'identifier.uri' in v5 not found.")
         return from_map
 
     @property
     def V5_DATE_ISSUED(self):
         from_map = self.get_field_id_by_name_v5('date.issued')
-        assert 15 == from_map
+        if from_map is None:
+            raise ValueError("Field ID for 'date.issued' in v5 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_LIC(self):
-        return 63
-        from_map = self.get_field_id_by_name('date.issued')
-        assert 63 == from_map
+        from_map = self.get_field_id_by_name('rights.uri')
+        if from_map is None:
+            raise ValueError("Field ID for 'rights.uri' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_DATE_ISSUED(self):
-        return 22
+        from_map = self.get_field_id_by_name('date.issued')
+        if from_map is None:
+            raise ValueError("Field ID for 'date.issued' in v7 not found.")
+        return from_map
 
     @property
     def V7_FIELD_LANG_ADDED(self):
-        return 149
-        from_map = self.get_field_id_by_name('date.issued')
-        assert 149 == from_map
+        from_map = self.get_field_id_by_name('language.name')
+        if from_map is None:
+            raise ValueError("Field ID for 'language.name' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_IDENTIFIER_URI(self):
-        return 34
         from_map = self.get_field_id_by_name('identififer.uri')
-        assert 34 == from_map
+        if from_map is None:
+            raise ValueError("Field ID for 'identififer.uri' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_TITLE(self):
-        return 74
         from_map = self.get_field_id_by_name('title.None')
-        assert 74 == from_map
+        if from_map is None:
+            raise ValueError("Field ID for 'title.None' in v7 not found.")
         return from_map
 
     @property
     def V7_FIELD_ID_PROVENANCE(self):
-        return 37
-        from_map = self.get_field_id_by_name('provenance.None')
-        assert 37 == from_map
+        from_map = self.get_field_id_by_name('description.provenance')
+        if from_map is None:
+            raise ValueError("Field ID for 'description.provenance' in v7 not found.")
         return from_map
 
     # =====

--- a/src/pump/_metadata.py
+++ b/src/pump/_metadata.py
@@ -262,12 +262,12 @@ class metadatas:
         - If name contains exactly one dot, append '.None' suffix.
         - Otherwise, return name as is.
         """
-        dot_count = name.count('.')
-        if dot_count > 2 or dot_count < 1:
-            return None
-        if dot_count == 1:
-            return name + ".None"
-        return name
+        dots = name.count('.')
+        if dots == 1:
+            return f"{name}.None"
+        if dots == 2:
+            return name
+        return None
 
     def get_field_id_by_name_v5(self, name: str):
         """

--- a/src/pump/_repo.py
+++ b/src/pump/_repo.py
@@ -94,6 +94,7 @@ class repo:
             env,
             dspace,
             _f_7("metadatafieldregistry"),
+            _f_7("metadataschemaregistry"),
             _f("metadatavalue"),
             _f("metadatafieldregistry"),
             _f("metadataschemaregistry"),

--- a/src/pump/_repo.py
+++ b/src/pump/_repo.py
@@ -43,14 +43,9 @@ class repo:
         self.raw_db_7 = db(env["db_dspace_7"])
 
         if not env["tempdb"]:
-            # remove directory
-            if os.path.exists(env["input"]["tempdbexport_v5"]):
-                shutil.rmtree(env["input"]["tempdbexport_v5"])
-
-        if not env["tempdb"]:
-            # remove directory
-            if os.path.exists(env["input"]["tempdbexport_v7"]):
-                shutil.rmtree(env["input"]["tempdbexport_v7"])
+            for path in [env["input"]["tempdbexport_v5"], env["input"]["tempdbexport_v7"]]:
+                if os.path.exists(path):
+                    shutil.rmtree(path)
 
         tables_db_5 = [x for arr in self.raw_db_dspace_5.all_tables() for x in arr]
         tables_utilities_5 = [x for arr in self.raw_db_utilities_5.all_tables()

--- a/src/pump/_repo.py
+++ b/src/pump/_repo.py
@@ -40,20 +40,26 @@ class repo:
     def __init__(self, env: dict, dspace):
         self.raw_db_dspace_5 = db(env["db_dspace_5"])
         self.raw_db_utilities_5 = db(env["db_utilities_5"])
+        self.raw_db_7 = db(env["db_dspace_7"])
 
         if not env["tempdb"]:
             # remove directory
-            if os.path.exists(env["input"]["tempdbexport"]):
-                shutil.rmtree(env["input"]["tempdbexport"])
+            if os.path.exists(env["input"]["tempdbexport_v5"]):
+                shutil.rmtree(env["input"]["tempdbexport_v5"])
+
+        if not env["tempdb"]:
+            # remove directory
+            if os.path.exists(env["input"]["tempdbexport_v7"]):
+                shutil.rmtree(env["input"]["tempdbexport_v7"])
 
         tables_db_5 = [x for arr in self.raw_db_dspace_5.all_tables() for x in arr]
         tables_utilities_5 = [x for arr in self.raw_db_utilities_5.all_tables()
                               for x in arr]
 
         def _f(table_name):
-            """ Dynamically export the table to json file and return path to it. """
-            os.makedirs(env["input"]["tempdbexport"], exist_ok=True)
-            out_f = os.path.join(env["input"]["tempdbexport"], f"{table_name}.json")
+            """ Dynamically export the table to json file and return path to it in v5. """
+            os.makedirs(env["input"]["tempdbexport_v5"], exist_ok=True)
+            out_f = os.path.join(env["input"]["tempdbexport_v5"], f"{table_name}.json")
             if not env["tempdb"]:
                 if table_name in tables_db_5:
                     db = self.raw_db_dspace_5
@@ -63,6 +69,14 @@ class repo:
                     _logger.warning(f"Table [{table_name}] not found in db.")
                     raise NotImplementedError(f"Table [{table_name}] not found in db.")
                 export_table(db, table_name, out_f)
+            return out_f
+
+        def _f_7(table_name):
+            """ Dynamically export the table to json file and return path to it for DSpace 7. """
+            os.makedirs(env["input"]["tempdbexport_v7"], exist_ok=True)
+            out_f = os.path.join(env["input"]["tempdbexport_v7"], f"{table_name}.json")
+            if not env["tempdb"]:
+                export_table(self.raw_db_7, table_name, out_f)
             return out_f
 
         # load groups
@@ -79,6 +93,7 @@ class repo:
         self.metadatas = metadatas(
             env,
             dspace,
+            _f_7("metadatafieldregistry"),
             _f("metadatavalue"),
             _f("metadatafieldregistry"),
             _f("metadataschemaregistry"),
@@ -152,8 +167,6 @@ class repo:
         self.resourcepolicies = resourcepolicies(
             _f("resourcepolicy")
         )
-
-        self.raw_db_7 = db(env["db_dspace_7"])
 
         self.sequences = sequences()
 

--- a/src/repo_import.py
+++ b/src/repo_import.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
                         required=False, type=str, default="")
     parser.add_argument('--tempdb',
                         help='Tempdbesport exists',
-                        required=False, action="store_true", default=False)
+                        required=False, action="store_true", default=True)
 
     args = parser.parse_args()
     s = time.time()

--- a/src/repo_import.py
+++ b/src/repo_import.py
@@ -56,8 +56,8 @@ if __name__ == "__main__":
                         help='Location of assetstore folder',
                         required=False, type=str, default="")
     parser.add_argument('--tempdb',
-                        help='Tempdbesport exists',
-                        required=False, action="store_true", default=True)
+                        help='Tempdb export exists',
+                        required=False, action="store_true", default=False)
 
     args = parser.parse_args()
     s = time.time()


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  3 |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
IDs for metadata fields are hardcoded as constants, so the code is not usable for a different CLARIN dump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Support for separate handling of metadata schemas and fields for two versions, improving compatibility and flexibility.
  * Added configuration options to specify metadata fields to ignore or replace during import.
  * Enhanced database export functionality to separately process data from two different system versions.
  * Default behavior updated to enable temporary database export unless explicitly disabled.

* **Bug Fixes**
  * Improved error handling for missing metadata fields by raising clear error messages instead of failing silently or with assertions. Users will now receive explicit feedback if required metadata fields are unavailable.

* **Documentation**
  * Corrected help text for temporary database export command-line option for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->