### PR TITLE
renamed password param in eperson endpoint

### DIFF
--- a/src/pump/_eperson.py
+++ b/src/pump/_eperson.py
@@ -113,7 +113,7 @@ class epersons:
             params = {
                 'selfRegistered': e.get('self_registered'),
                 'lastActive': e.get('last_active'),
-                'password': e.get('password'),
+                'passwordHashStr': e.get('password'),
                 'salt': e.get('salt'),
                 'digestAlgorithm': e.get('digest_algorithm')
             }


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Renamed parameter password to passwordHashStr for better clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the password parameter name used during user import to improve compatibility with external systems. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->