### PR TITLE
import/Configuration for version date field fix

### DIFF
--- a/src/pump/_item.py
+++ b/src/pump/_item.py
@@ -495,7 +495,7 @@ SELECT setval('versionhistory_seq', {versionhistory_new_id})
                         qualifier = field_parts[2] if len(field_parts) > 2 else None
 
                         # Single query that handles both qualified and unqualified fields
-                        qualifier_condition = f"and qualifier = '{qualifier}'" if qualifier else "and qualifier IS NULL"
+                        qualifier_condition = "and qualifier = %s" if qualifier else "and qualifier IS NULL"
 
                         query = """
                                 SELECT text_value


### PR DESCRIPTION
… using parameterized qualifier condition

| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Fix SQL placeholder/parameter mismatch in version date field query by using parameterized qualifier condition.
_Previous pull: https://github.com/dataquest-dev/dspace-import/pull/237_
