### PR TITLE
Fix sql parametrization for multiple statements

### DIFF
--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -262,24 +262,14 @@ class db:
 
         Args:
             sql_text: SQL to execute
-            params: Optional parameters for parameterized query
+            params: Optional dict of named parameters for parameterized query.
+                   Only dict format is supported (e.g., {'name': 'value'} for %(name)s placeholders).
+                   Positional parameters (tuple/list) are not supported.
 
         Behavior:
             - With params: Executes single parameterized statement only
             - Without params: Can execute multiple statements (split by newlines)
-
-        Raises:
-            ValueError: If params provided but sql_text contains multiple statements
         """
-        # Validate that parameterized queries only contain single statements
-        if params is not None:
-            sql_lines = [x.strip() for x in (sql_text or "").splitlines() if x.strip()]
-            if len(sql_lines) > 1:
-                raise ValueError(
-                    "Parameterized queries must contain only a single SQL statement. "
-                    f"Found {len(sql_lines)} statements. Use separate calls for multiple statements."
-                )
-
         max_retries = DB_MAX_RETRIES
 
         for attempt in range(max_retries):

--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -267,8 +267,10 @@ class db:
                    Positional parameters (tuple/list) are not supported.
 
         Behavior:
-            - With params: Executes single parameterized statement only
-            - Without params: Can execute multiple statements (split by newlines)
+            - With params: Performs a single cursor.execute(sql_text, params) call. If sql_text
+              contains multiple statements, execution behavior is determined by the database/driver.
+            - Without params: Splits sql_text into non-empty lines and executes each line as a
+              separate statement.
         """
         max_retries = DB_MAX_RETRIES
 


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.2  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Error during import: ValueError: Parameterized queries must contain only a single SQL statement. Found 4 statements. Use separate calls for multiple statements.
