### PR TITLE
UFAL/User registration removed email during import

### DIFF
--- a/src/pump/_userregistration.py
+++ b/src/pump/_userregistration.py
@@ -7,8 +7,7 @@ _logger = logging.getLogger("pump.userregistration")
 class userregistrations:
     validate_table = [
         # ["userregistration", {
-        #     # do not use compare because of email field (GDPR)
-        #     "compare": ["email", "netid"],
+        #     "compare": ["eperson_id"],
         # }],
     ]
 
@@ -46,15 +45,17 @@ class userregistrations:
         log_before_import(log_key, expected)
 
         for ur in progress_bar(self._ur):
-            data = {
-                'email': ur['email'],
-                'organization': ur['organization'],
-                'confirmation': ur['confirmation']
-            }
             e_id = ur['eperson_id']
-            e_id_by_email = epersons.by_email(ur['email'])
-            data['ePersonID'] = epersons.uuid(
-                e_id_by_email) if e_id_by_email is not None else None
+
+            if str(e_id) in self._id2uuid:
+                _logger.debug(f"Skipping already-imported eperson_id [{e_id}]")
+                continue
+
+            data = {
+                'organization': ur['organization'],
+                'confirmation': ur['confirmation'],
+                'ePersonID': epersons.uuid(e_id),
+            }
             try:
                 resp = dspace.put_userregistration(data)
                 self._id2uuid[str(e_id)] = resp['id']


### PR DESCRIPTION
| Phases            | MS | MM  |  MK  | JR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The user_registration table was updated. The eperson_id is now unique, and the email column was removed. The import needed to be updated accordingly.