### PR TITLE
chore: bump actions/* to latest majors

### DIFF
--- a/.github/workflows/new_issue_assign.yml
+++ b/.github/workflows/new_issue_assign.yml
@@ -9,7 +9,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v2
         with:
           # You can target a project in a different organization
           # to the issue

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive      
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           


### PR DESCRIPTION
Bumps the `actions/*` workflow deps actually used in this repo to current major (verified 2026-05-17):

| Action | Old | New |
|---|---|---|
| `actions/add-to-project` | v0.5.0 | **v2** |
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |

**CI note:** `test.yml` runs on push (was `disabled_inactivity`; re-enabled). `new_issue_assign.yml` add-to-project bump is **not exercised** by this PR (triggers on `issues` only) — verify by opening a test issue after merge.