### PR TITLE
UoE/Python integration script for resourcePolicies set-up

### DIFF
--- a/tools/replace_resource_policies/README.md
+++ b/tools/replace_resource_policies/README.md
@@ -1,7 +1,7 @@
-﻿# Set READ Resource Policies to Administrator
+﻿# Set READ Resource Policies to a Group
 
 ## Goal
-Set or replace all READ resource policies on each item's ORIGINAL bundle and its bitstreams so only the Administrator group has READ access.
+Set or replace all READ resource policies on each item's ORIGINAL bundle and its bitstreams so only a single chosen group has READ access. The default group is `Administrator`; pass `--group Anonymous` to make the files publicly readable.
 
 ## Security Rules
 - Do not store endpoints, handles, usernames, or passwords in this repository.
@@ -29,6 +29,35 @@ python tools/replace_resource_policies/set_admin_policies.py \
   --handle "12345/1001" \
   --handle "12345/1002"
 
+## Authentication
+Two options:
+
+1. User/password (default): pass --email and --password.
+
+2. Bearer token (for Shibboleth/SAML-only instances): the project has no Shibboleth
+   login flow, but the REST API authenticates every call with a JWT, so you can reuse a
+   token from a browser session:
+   - Log in to the DSpace UI in the browser via Shibboleth.
+   - Open DevTools -> Network, click any /api/... request, and copy the value of the
+     "Authorization: Bearer <token>" request header (the part after "Bearer ").
+   - Pass it as --bearer-token "<token>" instead of --email/--password.
+   - The token is short-lived (DSpace default ~30 min), so run the script promptly.
+
+Example (Shibboleth-only instance, set handles public for Anonymous):
+python tools/replace_resource_policies/set_admin_policies.py --base-url "https://example-dspace.invalid/server" --bearer-token "eyJhbGci...REDACTED" --handles "12345/1001,12345/1002" --group "Anonymous" --dry-run
+
+## Target Group
+- --group <name>  Exact group name that receives the READ policy. Default: "Administrator".
+  Use --group "Anonymous" to make the files publicly readable.
+
+Example (make handles public for Anonymous):
+python tools/replace_resource_policies/set_admin_policies.py \
+  --base-url "https://example-dspace.invalid/server" \
+  --email "admin@example.invalid" \
+  --password "CHANGE_ME" \
+  --handles "12345/1001,12345/1002" \
+  --group "Anonymous"
+
 ## Optional Resilience Flags
 - --timeout-sec <seconds>
 - --retry-count <n>
@@ -39,13 +68,13 @@ python tools/replace_resource_policies/set_admin_policies.py \
 ## API Flow
 1. GET /api/security/csrf
 2. POST /api/authn/login
-3. GET /api/eperson/groups/search/byMetadata?query=Administrator
+3. GET /api/eperson/groups/search/byMetadata?query=<group> (default Administrator, e.g. Anonymous)
 4. Resolve handle with /api/pid/find, fallback to /api/discover/search/objects
 5. GET item ORIGINAL bundle and bitstreams
 6. For each target resource:
 - GET existing READ policies
 - DELETE existing READ policies
-- POST new READ policy for Administrator group
+- POST new READ policy for the target group
 7. POST /api/authn/logout
 
 ## Output Summary

--- a/tools/replace_resource_policies/README.md
+++ b/tools/replace_resource_policies/README.md
@@ -1,0 +1,54 @@
+﻿# Set READ Resource Policies to Administrator
+
+## Goal
+Set or replace all READ resource policies on each item's ORIGINAL bundle and its bitstreams so only the Administrator group has READ access.
+
+## Security Rules
+- Do not store endpoints, handles, usernames, or passwords in this repository.
+- Pass endpoint and credentials only through script arguments at runtime.
+- Use made-up placeholder values in documentation and examples.
+
+## Script
+- Path: tools/replace_resource_policies/set_admin_policies.py
+
+## Input Mode
+Handles are passed directly in arguments.
+
+1. Comma-separated handles:
+python tools/replace_resource_policies/set_admin_policies.py \
+  --base-url "https://example-dspace.invalid/server" \
+  --email "admin@example.invalid" \
+  --password "CHANGE_ME" \
+  --handles "12345/1001,12345/1002,12345/1003"
+
+2. Repeated handle argument:
+python tools/replace_resource_policies/set_admin_policies.py \
+  --base-url "https://example-dspace.invalid/server" \
+  --email "admin@example.invalid" \
+  --password "CHANGE_ME" \
+  --handle "12345/1001" \
+  --handle "12345/1002"
+
+## Optional Resilience Flags
+- --timeout-sec <seconds>
+- --retry-count <n>
+- --retry-backoff-sec <seconds>
+- --continue-on-bitstream-error
+- --dry-run
+
+## API Flow
+1. GET /api/security/csrf
+2. POST /api/authn/login
+3. GET /api/eperson/groups/search/byMetadata?query=Administrator
+4. Resolve handle with /api/pid/find, fallback to /api/discover/search/objects
+5. GET item ORIGINAL bundle and bitstreams
+6. For each target resource:
+- GET existing READ policies
+- DELETE existing READ policies
+- POST new READ policy for Administrator group
+7. POST /api/authn/logout
+
+## Output Summary
+- Per handle: bitstreams attempted and failed.
+- Final run: total bitstreams attempted and failed.
+- Final run: aggregate failure counts by reason.

--- a/tools/replace_resource_policies/set_admin_policies.py
+++ b/tools/replace_resource_policies/set_admin_policies.py
@@ -1,0 +1,729 @@
+"""Set READ policies on ORIGINAL bundles and bitstreams to Administrator only."""
+
+import argparse
+import logging
+import os
+import re
+import sys
+import time
+from typing import Any, Optional
+
+import requests
+
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_this_dir, "../../src"))
+
+import settings  # noqa: E402
+import project_settings  # noqa: E402
+from utils import init_logging, update_settings  # noqa: E402
+
+_logger = logging.getLogger()
+
+# env settings, update with project_settings
+env = update_settings(settings.env, project_settings.settings)
+init_logging(_logger, env["log_file"])
+
+DEFAULT_TIMEOUT_SEC = 30.0
+DEFAULT_RETRY_COUNT = 3
+DEFAULT_RETRY_BACKOFF_SEC = 1.0
+RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+
+
+# ---------------------------------------------------------------------------
+# DSpace REST client
+# ---------------------------------------------------------------------------
+
+class DSpaceClient:
+    """Thin wrapper around the DSpace 8 REST API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        dry_run: bool = False,
+        timeout_sec: float = DEFAULT_TIMEOUT_SEC,
+        retry_count: int = DEFAULT_RETRY_COUNT,
+        retry_backoff_sec: float = DEFAULT_RETRY_BACKOFF_SEC,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.dry_run = dry_run
+        self.timeout_sec = timeout_sec
+        self.retry_count = retry_count
+        self.retry_backoff_sec = retry_backoff_sec
+        self.session = requests.Session()
+        self.jwt: Optional[str] = None
+        self.csrf_token: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _auth_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.jwt:
+            headers["Authorization"] = f"Bearer {self.jwt}"
+        if self.csrf_token:
+            headers["X-XSRF-TOKEN"] = self.csrf_token
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[dict[str, str]] = None,
+        params: Optional[dict[str, Any]] = None,
+        data: Optional[dict[str, Any]] = None,
+        json: Optional[dict[str, Any]] = None,
+        allow_redirects: bool = True,
+        retries: Optional[int] = None,
+        retry_on_status: bool = True,
+    ) -> requests.Response:
+        """Send HTTP request with explicit timeout and bounded retry/backoff."""
+        attempts = (self.retry_count if retries is None else retries) + 1
+        last_exc: Optional[Exception] = None
+        method_upper = method.upper()
+
+        for attempt in range(1, attempts + 1):
+            try:
+                response = self.session.request(
+                    method=method_upper,
+                    url=url,
+                    headers=headers,
+                    params=params,
+                    data=data,
+                    json=json,
+                    timeout=self.timeout_sec,
+                    allow_redirects=allow_redirects,
+                )
+                if retry_on_status and response.status_code in RETRYABLE_STATUS_CODES:
+                    if attempt < attempts:
+                        delay = self.retry_backoff_sec * (2 ** (attempt - 1))
+                        _logger.warning(
+                            "%s %s returned %s; retrying in %.1fs (%d/%d)",
+                            method_upper,
+                            url,
+                            response.status_code,
+                            delay,
+                            attempt,
+                            attempts,
+                        )
+                        time.sleep(delay)
+                        continue
+                return response
+            except requests.RequestException as exc:
+                last_exc = exc
+                if attempt < attempts:
+                    delay = self.retry_backoff_sec * (2 ** (attempt - 1))
+                    _logger.warning(
+                        "%s %s failed (%s); retrying in %.1fs (%d/%d)",
+                        method_upper,
+                        url,
+                        exc,
+                        delay,
+                        attempt,
+                        attempts,
+                    )
+                    time.sleep(delay)
+                    continue
+                break
+
+        if last_exc is not None:
+            raise RuntimeError(f"HTTP request failed after retries: {method_upper} {url}") from last_exc
+        raise RuntimeError(f"HTTP request failed after retries: {method_upper} {url}")
+
+    def _refresh_csrf(self) -> None:
+        """Fetch a fresh CSRF token from /api/security/csrf."""
+        response = self._request(
+            "GET",
+            f"{self.base_url}/api/security/csrf",
+            headers={"Accept": "application/json"},
+            retries=self.retry_count,
+        )
+        response.raise_for_status()
+        # DSpace returns the token both in a response header and a cookie.
+        token = response.headers.get("DSPACE-XSRF-TOKEN") or response.cookies.get(
+            "DSPACE-XSRF-COOKIE"
+        )
+        if token:
+            self.csrf_token = token
+            _logger.debug("CSRF token refreshed")
+        else:
+            _logger.warning("Could not retrieve CSRF token from /api/security/csrf")
+
+    def _get_all_pages(self, url: str, embedded_key: str) -> list[dict[str, Any]]:
+        """
+        Collect all items from a paginated HAL response.
+
+        :param url:          Initial URL (may already have query params).
+        :param embedded_key: Key inside '_embedded' that holds the list.
+        :return:             Flat list of all items across all pages.
+        """
+        results: list[dict[str, Any]] = []
+        # Force large page size to minimise round-trips
+        sep = "&" if "?" in url else "?"
+        next_url = f"{url}{sep}size=100&page=0"
+
+        while next_url:
+            response = self._request(
+                "GET",
+                next_url,
+                headers=self._auth_headers(),
+                retries=self.retry_count,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            embedded = data.get("_embedded", {})
+            page_items = embedded.get(embedded_key, [])
+            results.extend(page_items)
+
+            page = data.get("page", {})
+            total_pages = page.get("totalPages", 1)
+            current_page = page.get("number", 0)
+
+            if current_page + 1 < total_pages:
+                # Build the URL for the next page
+                base_url_no_page = re.sub(r"[?&]page=\d+", "", next_url)
+                sep2 = "&" if "?" in base_url_no_page else "?"
+                next_url = f"{base_url_no_page}{sep2}page={current_page + 1}"
+            else:
+                next_url = None
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
+    def login(self, email: str, password: str) -> None:
+        """Authenticate and store the JWT token."""
+        self._refresh_csrf()
+
+        response = self._request(
+            "POST",
+            f"{self.base_url}/api/authn/login",
+            data={"user": email, "password": password},
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-XSRF-TOKEN": self.csrf_token or "",
+            },
+            retry_on_status=False,
+        )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Login failed ({response.status_code}): {response.text[:200]}"
+            )
+
+        auth_header = response.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise RuntimeError("Login response did not contain a Bearer JWT token.")
+        self.jwt = auth_header.split(" ", 1)[1]
+        # Refresh CSRF after login (DSpace 8 may rotate it)
+        self._refresh_csrf()
+        _logger.info("Logged in successfully as %s", email)
+
+    def logout(self) -> None:
+        if not self.jwt:
+            return
+        self._request(
+            "POST",
+            f"{self.base_url}/api/authn/logout",
+            headers=self._auth_headers(),
+            retry_on_status=False,
+        )
+        _logger.info("Logged out.")
+        self.jwt = None
+
+    # ------------------------------------------------------------------
+    # Group / Admin lookup
+    # ------------------------------------------------------------------
+
+    def find_administrator_group_uuid(self) -> str:
+        """Return the UUID of the built-in 'Administrator' group."""
+        groups = self._get_all_pages(
+            f"{self.base_url}/api/eperson/groups/search/byMetadata?query=Administrator",
+            "groups",
+        )
+        for group in groups:
+            if group.get("name") == "Administrator":
+                uuid = group["uuid"]
+                _logger.info("Found Administrator group UUID: %s", uuid)
+                return uuid
+        raise RuntimeError(
+            "Could not find the 'Administrator' group via the REST API. "
+            "Ensure the account has admin privileges."
+        )
+
+    # ------------------------------------------------------------------
+    # Handle resolution
+    # ------------------------------------------------------------------
+
+    def resolve_handle(self, handle: str) -> Optional[str]:
+        """
+        Resolve a handle string (e.g. '10283/1911') to an item UUID.
+        First tries /api/pid/find (returns 302 redirect on success).
+        Falls back to /api/discover/search/objects when pid/find returns 404.
+        Returns None if the handle cannot be resolved.
+        """
+        response = self._request(
+            "GET",
+            f"{self.base_url}/api/pid/find",
+            params={"id": handle},
+            headers=self._auth_headers(),
+            allow_redirects=False,
+            retries=self.retry_count,
+        )
+        if response.status_code == 302:
+            location = response.headers.get("Location", "")
+            # Extract UUID from a URL like .../api/core/items/<uuid>
+            match = re.search(r"/api/core/items/([0-9a-f-]{36})", location)
+            if match:
+                return match.group(1)
+            _logger.warning("Unexpected redirect location for handle %s: %s", handle, location)
+            return None
+
+        if response.status_code not in (404, 200):
+            _logger.warning(
+                "Unexpected status %s when resolving handle %s via pid/find: %s",
+                response.status_code, handle, response.text[:200],
+            )
+
+        # Fallback: search via discovery API
+        _logger.debug(
+            "pid/find returned %s for %s - trying discover search",
+            response.status_code,
+            handle,
+        )
+        discover_response = self._request(
+            "GET",
+            f"{self.base_url}/api/discover/search/objects",
+            params={"query": f"handle:{handle}", "dsoType": "ITEM"},
+            headers=self._auth_headers(),
+            retries=self.retry_count,
+        )
+        if discover_response.status_code != 200:
+            _logger.warning("Handle not found: %s", handle)
+            return None
+        data = discover_response.json()
+        objects = (
+            data.get("_embedded", {})
+            .get("searchResult", {})
+            .get("_embedded", {})
+            .get("objects", [])
+        )
+        for obj in objects:
+            embedded = obj.get("_embedded", {}).get("indexableObject", {})
+            if embedded.get("handle") == handle:
+                return embedded.get("uuid")
+        _logger.warning("Handle not found in discover results: %s", handle)
+        return None
+
+    # ------------------------------------------------------------------
+    # Item / Bundle / Bitstream
+    # ------------------------------------------------------------------
+
+    def get_original_bundle(self, item_uuid: str) -> Optional[dict]:
+        """Return the ORIGINAL bundle object for the given item, or None."""
+        bundles = self._get_all_pages(
+            f"{self.base_url}/api/core/items/{item_uuid}/bundles",
+            "bundles",
+        )
+        for bundle in bundles:
+            if bundle.get("name") == "ORIGINAL":
+                return bundle
+        _logger.warning("No ORIGINAL bundle found for item %s", item_uuid)
+        return None
+
+    def get_bitstreams(self, bundle_uuid: str) -> list:
+        """Return all bitstream objects from the given bundle."""
+        return self._get_all_pages(
+            f"{self.base_url}/api/core/bundles/{bundle_uuid}/bitstreams",
+            "bitstreams",
+        )
+
+    # ------------------------------------------------------------------
+    # Resource policies
+    # ------------------------------------------------------------------
+
+    def get_read_policies(self, resource_uuid: str) -> list:
+        """Return all existing READ resource policies for a resource."""
+        return self._get_all_pages(
+            f"{self.base_url}/api/authz/resourcepolicies/search/resource"
+            f"?uuid={resource_uuid}&action=READ",
+            "resourcepolicies",
+        )
+
+    def delete_policy(self, policy_id: int) -> bool:
+        """Delete a resource policy by its integer ID. Returns True on success."""
+        if self.dry_run:
+            _logger.info("[DRY-RUN] Would DELETE policy id=%s", policy_id)
+            return True
+        response = self._request(
+            "DELETE",
+            f"{self.base_url}/api/authz/resourcepolicies/{policy_id}",
+            headers=self._auth_headers(),
+            retries=self.retry_count,
+        )
+        if response.status_code == 204:
+            _logger.debug("Deleted policy id=%s", policy_id)
+            return True
+        if response.status_code == 404:
+            _logger.debug("Policy id=%s already gone (404)", policy_id)
+            return True
+        _logger.error(
+            "Failed to delete policy id=%s: %s %s",
+            policy_id,
+            response.status_code,
+            response.text[:200],
+        )
+        return False
+
+    def create_read_policy(self, resource_uuid: str, admin_group_uuid: str) -> bool:
+        """
+        Create a READ resource policy on *resource_uuid* for the Administrator group.
+        Returns True on success.
+        """
+        if self.dry_run:
+            _logger.info(
+                "[DRY-RUN] Would POST READ policy resource=%s group=%s",
+                resource_uuid, admin_group_uuid,
+            )
+            return True
+
+        response = self._request(
+            "POST",
+            f"{self.base_url}/api/authz/resourcepolicies",
+            params={"resource": resource_uuid, "group": admin_group_uuid},
+            json={"action": "READ", "type": "resourcepolicy"},
+            headers={**self._auth_headers(), "Content-Type": "application/json"},
+            retry_on_status=False,
+        )
+        if response.status_code in (200, 201):
+            _logger.debug(
+                "Created READ policy for resource=%s group=%s", resource_uuid, admin_group_uuid
+            )
+            return True
+        _logger.error(
+            "Failed to create READ policy for resource=%s: %s %s",
+            resource_uuid,
+            response.status_code,
+            response.text[:200],
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    # High-level operation
+    # ------------------------------------------------------------------
+
+    def restrict_to_admin(self, resource_uuid: str, admin_group_uuid: str, label: str) -> bool:
+        """
+        Replace all READ policies on *resource_uuid* with a single Administrator-only policy.
+        *label* is used only for log messages (e.g. 'bundle', 'bitstream <name>').
+        """
+        existing_policies = self.get_read_policies(resource_uuid)
+        _logger.info(
+            "  %s [%s]: found %d existing READ polic(y/ies)",
+            label, resource_uuid, len(existing_policies),
+        )
+
+        all_deleted = True
+        for policy in existing_policies:
+            policy_id = policy.get("id")
+            if policy_id is not None:
+                all_deleted = self.delete_policy(policy_id) and all_deleted
+
+        created = self.create_read_policy(resource_uuid, admin_group_uuid)
+        if all_deleted and created:
+            _logger.info("  %s [%s]: READ policy set to Administrator only.", label, resource_uuid)
+            return True
+        _logger.error("  %s [%s]: failed to fully update READ policy.", label, resource_uuid)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Input parsing
+# ---------------------------------------------------------------------------
+
+def parse_handles_csv(raw_handles: str) -> list[str]:
+    """
+    Parse comma-separated handles from CLI input.
+    Accepts formats like:
+        "12345/1001","12345/1002"
+        12345/1001, 12345/1002
+    """
+    handles: list[str] = []
+    # Split by comma, strip whitespace and surrounding quotes
+    for part in raw_handles.split(","):
+        handle = part.strip().strip('"').strip("'").strip()
+        if handle:
+            handles.append(handle)
+    return handles
+
+
+def collect_handles(raw_handles: Optional[str], repeated_handles: Optional[list[str]]) -> list[str]:
+    """Merge handles from --handles and repeated --handle arguments."""
+    merged: list[str] = []
+    if raw_handles:
+        merged.extend(parse_handles_csv(raw_handles))
+    if repeated_handles:
+        for handle in repeated_handles:
+            val = handle.strip().strip('"').strip("'").strip()
+            if val:
+                merged.append(val)
+    return merged
+
+
+def process_handle(
+    client: DSpaceClient,
+    handle: str,
+    admin_group_uuid: str,
+    continue_on_bitstream_error: bool = False,
+) -> dict[str, Any]:
+    """Process one handle and restrict bundle + bitstreams to Administrator group."""
+    result: dict[str, Any] = {
+        "handle": handle,
+        "success": False,
+        "reason": None,
+        "bitstreams_attempted": 0,
+        "bitstreams_failed": 0,
+    }
+
+    _logger.info("=" * 60)
+    _logger.info("Processing handle: %s", handle)
+
+    item_uuid = client.resolve_handle(handle)
+    if not item_uuid:
+        _logger.warning("Skipping handle %s (could not resolve).", handle)
+        result["reason"] = "unresolved_handle"
+        return result
+
+    _logger.info("  Resolved to item UUID: %s", item_uuid)
+
+    original_bundle = client.get_original_bundle(item_uuid)
+    if not original_bundle:
+        _logger.warning("Skipping handle %s (no ORIGINAL bundle).", handle)
+        result["reason"] = "missing_original_bundle"
+        return result
+
+    bundle_uuid = original_bundle["uuid"]
+    _logger.info("  ORIGINAL bundle UUID: %s", bundle_uuid)
+
+    bitstreams = client.get_bitstreams(bundle_uuid)
+    _logger.info("  Found %d bitstream(s) in ORIGINAL bundle.", len(bitstreams))
+    result["bitstreams_attempted"] = len(bitstreams)
+
+    if not client.restrict_to_admin(bundle_uuid, admin_group_uuid, "ORIGINAL bundle"):
+        result["reason"] = "bundle_policy_update_failed"
+        return result
+
+    failed_bitstreams = 0
+    for bitstream in bitstreams:
+        bitstream_uuid = bitstream["uuid"]
+        bitstream_name = bitstream.get("name", bitstream_uuid)
+        if not client.restrict_to_admin(
+            bitstream_uuid,
+            admin_group_uuid,
+            f"bitstream '{bitstream_name}'",
+        ):
+            failed_bitstreams += 1
+            result["bitstreams_failed"] = failed_bitstreams
+            if continue_on_bitstream_error:
+                _logger.warning(
+                    "  bitstream '%s' [%s]: failed; continuing due to --continue-on-bitstream-error",
+                    bitstream_name,
+                    bitstream_uuid,
+                )
+                continue
+            result["reason"] = "bitstream_policy_update_failed"
+            _logger.info(
+                "Handle %s summary: bitstreams attempted=%d, failed=%d",
+                handle,
+                result["bitstreams_attempted"],
+                result["bitstreams_failed"],
+            )
+            return result
+
+    if failed_bitstreams > 0:
+        _logger.warning(
+            "Handle %s finished with %d failed bitstream policy update(s).",
+            handle,
+            failed_bitstreams,
+        )
+        result["reason"] = "bitstream_policy_update_failed"
+        _logger.info(
+            "Handle %s summary: bitstreams attempted=%d, failed=%d",
+            handle,
+            result["bitstreams_attempted"],
+            result["bitstreams_failed"],
+        )
+        return result
+
+    _logger.info("Handle %s processed successfully.", handle)
+    result["success"] = True
+    _logger.info(
+        "Handle %s summary: bitstreams attempted=%d, failed=%d",
+        handle,
+        result["bitstreams_attempted"],
+        result["bitstreams_failed"],
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Set READ policies on ORIGINAL bundles/bitstreams to Administrator only."
+    )
+    handles_group = parser.add_mutually_exclusive_group(required=True)
+    handles_group.add_argument(
+        "--handles",
+        help=(
+            "Comma-separated item handles, e.g. \"12345/1001,12345/1002\". "
+            "Quotes around each handle are optional."
+        ),
+    )
+    handles_group.add_argument(
+        "--handle",
+        action="append",
+        help="Single item handle. Repeat this argument to pass multiple handles.",
+    )
+    parser.add_argument(
+        "--base-url",
+        required=True,
+        help="DSpace REST base URL, e.g. https://example-dspace.invalid/server",
+    )
+    parser.add_argument(
+        "--email",
+        required=True,
+        help="Admin account e-mail used for login.",
+    )
+    parser.add_argument(
+        "--password",
+        required=True,
+        help="Admin password",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be done without actually modifying any policies.",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=float,
+        default=DEFAULT_TIMEOUT_SEC,
+        help=f"HTTP request timeout in seconds (default: {DEFAULT_TIMEOUT_SEC}).",
+    )
+    parser.add_argument(
+        "--retry-count",
+        type=int,
+        default=DEFAULT_RETRY_COUNT,
+        help=f"Number of retries for retryable HTTP failures (default: {DEFAULT_RETRY_COUNT}).",
+    )
+    parser.add_argument(
+        "--retry-backoff-sec",
+        type=float,
+        default=DEFAULT_RETRY_BACKOFF_SEC,
+        help=(
+            "Base delay in seconds for exponential retry backoff "
+            f"(default: {DEFAULT_RETRY_BACKOFF_SEC})."
+        ),
+    )
+    parser.add_argument(
+        "--continue-on-bitstream-error",
+        action="store_true",
+        help=(
+            "Continue processing remaining bitstreams within a handle if one fails. "
+            "Default behavior (without this flag) stops processing the handle on first failure."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.timeout_sec <= 0:
+        _logger.error("--timeout-sec must be > 0")
+        sys.exit(1)
+    if args.retry_count < 0:
+        _logger.error("--retry-count must be >= 0")
+        sys.exit(1)
+    if args.retry_backoff_sec < 0:
+        _logger.error("--retry-backoff-sec must be >= 0")
+        sys.exit(1)
+
+    _logger.info(
+        "Arguments: base_url=%s, email=%s, dry_run=%s, timeout_sec=%s, retry_count=%s, "
+        "retry_backoff_sec=%s, continue_on_bitstream_error=%s, handles_mode=%s",
+        args.base_url,
+        args.email,
+        args.dry_run,
+        args.timeout_sec,
+        args.retry_count,
+        args.retry_backoff_sec,
+        args.continue_on_bitstream_error,
+        "--handles" if args.handles else "--handle",
+    )
+
+    handles = collect_handles(args.handles, args.handle)
+    if not handles:
+        _logger.error("No valid handles were provided via --handles or --handle")
+        sys.exit(1)
+    _logger.info("Loaded %d handle(s) from CLI arguments", len(handles))
+
+    client = DSpaceClient(
+        base_url=args.base_url,
+        dry_run=args.dry_run,
+        timeout_sec=args.timeout_sec,
+        retry_count=args.retry_count,
+        retry_backoff_sec=args.retry_backoff_sec,
+    )
+
+    try:
+        client.login(args.email, args.password)
+        admin_group_uuid = client.find_administrator_group_uuid()
+
+        success_count = 0
+        failure_count = 0
+        total_bitstreams_attempted = 0
+        total_bitstreams_failed = 0
+        failure_reasons: dict[str, int] = {}
+
+        for handle in handles:
+            handle_result = process_handle(
+                client,
+                handle,
+                admin_group_uuid,
+                continue_on_bitstream_error=args.continue_on_bitstream_error,
+            )
+
+            total_bitstreams_attempted += int(handle_result["bitstreams_attempted"])
+            total_bitstreams_failed += int(handle_result["bitstreams_failed"])
+
+            if handle_result["success"]:
+                success_count += 1
+            else:
+                failure_count += 1
+                reason = str(handle_result["reason"] or "unknown")
+                failure_reasons[reason] = failure_reasons.get(reason, 0) + 1
+
+        _logger.info("=" * 60)
+        _logger.info(
+            "Done. %d handle(s) processed successfully, %d skipped/failed.",
+            success_count, failure_count,
+        )
+        _logger.info(
+            "Bitstream summary: attempted=%d, failed=%d",
+            total_bitstreams_attempted,
+            total_bitstreams_failed,
+        )
+        if failure_reasons:
+            _logger.info("Aggregate failure report:")
+            for reason, count in sorted(failure_reasons.items()):
+                _logger.info("  %s: %d", reason, count)
+
+    finally:
+        client.logout()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/replace_resource_policies/set_admin_policies.py
+++ b/tools/replace_resource_policies/set_admin_policies.py
@@ -222,6 +222,39 @@ class DSpaceClient:
         self._refresh_csrf()
         _logger.info("Logged in successfully as %s", email)
 
+    def use_bearer_token(self, token: str) -> None:
+        """
+        Authenticate with a pre-obtained Bearer JWT instead of user/password login.
+
+        Useful when the instance only allows Shibboleth/SAML login: log in via the
+        browser, copy the JWT from the 'Authorization: Bearer <token>' request header
+        (DevTools -> Network), and pass it here. The token is short-lived (DSpace
+        default ~30 min), so run the script promptly after obtaining it.
+        """
+        token = token.strip()
+        # Accept either the raw token or a full "Bearer <token>" string.
+        if token.lower().startswith("bearer "):
+            token = token.split(" ", 1)[1].strip()
+        self.jwt = token
+        # We still need a CSRF token bound to *our* session for state-changing requests.
+        self._refresh_csrf()
+        # Verify the token is valid (and not expired) before doing any work.
+        response = self._request(
+            "GET",
+            f"{self.base_url}/api/authn/status",
+            headers={**self._auth_headers(), "Accept": "application/json"},
+            retries=self.retry_count,
+        )
+        response.raise_for_status()
+        status = response.json()
+        if not status.get("authenticated"):
+            raise RuntimeError(
+                "The provided --bearer-token is not valid or has expired. "
+                "Log in again via the browser and copy a fresh token."
+            )
+        email = status.get("_embedded", {}).get("eperson", {}).get("email", "<unknown>")
+        _logger.info("Authenticated via provided Bearer token as %s", email)
+
     def logout(self) -> None:
         if not self.jwt:
             return
@@ -238,20 +271,20 @@ class DSpaceClient:
     # Group / Admin lookup
     # ------------------------------------------------------------------
 
-    def find_administrator_group_uuid(self) -> str:
-        """Return the UUID of the built-in 'Administrator' group."""
+    def find_group_uuid(self, group_name: str) -> str:
+        """Return the UUID of a group by its exact name (e.g. 'Administrator', 'Anonymous')."""
         groups = self._get_all_pages(
-            f"{self.base_url}/api/eperson/groups/search/byMetadata?query=Administrator",
+            f"{self.base_url}/api/eperson/groups/search/byMetadata?query={group_name}",
             "groups",
         )
         for group in groups:
-            if group.get("name") == "Administrator":
+            if group.get("name") == group_name:
                 uuid = group["uuid"]
-                _logger.info("Found Administrator group UUID: %s", uuid)
+                _logger.info("Found '%s' group UUID: %s", group_name, uuid)
                 return uuid
         raise RuntimeError(
-            "Could not find the 'Administrator' group via the REST API. "
-            "Ensure the account has admin privileges."
+            f"Could not find the '{group_name}' group via the REST API. "
+            "Ensure the group name is correct and the account has admin privileges."
         )
 
     # ------------------------------------------------------------------
@@ -322,17 +355,16 @@ class DSpaceClient:
     # Item / Bundle / Bitstream
     # ------------------------------------------------------------------
 
-    def get_original_bundle(self, item_uuid: str) -> Optional[dict]:
-        """Return the ORIGINAL bundle object for the given item, or None."""
+    def get_original_bundles(self, item_uuid: str) -> list[dict]:
+        """Return all ORIGINAL bundle objects for the given item (an item may have more than one)."""
         bundles = self._get_all_pages(
             f"{self.base_url}/api/core/items/{item_uuid}/bundles",
             "bundles",
         )
-        for bundle in bundles:
-            if bundle.get("name") == "ORIGINAL":
-                return bundle
-        _logger.warning("No ORIGINAL bundle found for item %s", item_uuid)
-        return None
+        original_bundles = [b for b in bundles if b.get("name") == "ORIGINAL"]
+        if not original_bundles:
+            _logger.warning("No ORIGINAL bundle found for item %s", item_uuid)
+        return original_bundles
 
     def get_bitstreams(self, bundle_uuid: str) -> list:
         """Return all bitstream objects from the given bundle."""
@@ -378,29 +410,29 @@ class DSpaceClient:
         )
         return False
 
-    def create_read_policy(self, resource_uuid: str, admin_group_uuid: str) -> bool:
+    def create_read_policy(self, resource_uuid: str, group_uuid: str) -> bool:
         """
-        Create a READ resource policy on *resource_uuid* for the Administrator group.
+        Create a READ resource policy on *resource_uuid* for the target group.
         Returns True on success.
         """
         if self.dry_run:
             _logger.info(
                 "[DRY-RUN] Would POST READ policy resource=%s group=%s",
-                resource_uuid, admin_group_uuid,
+                resource_uuid, group_uuid,
             )
             return True
 
         response = self._request(
             "POST",
             f"{self.base_url}/api/authz/resourcepolicies",
-            params={"resource": resource_uuid, "group": admin_group_uuid},
+            params={"resource": resource_uuid, "group": group_uuid},
             json={"action": "READ", "type": "resourcepolicy"},
             headers={**self._auth_headers(), "Content-Type": "application/json"},
             retry_on_status=False,
         )
         if response.status_code in (200, 201):
             _logger.debug(
-                "Created READ policy for resource=%s group=%s", resource_uuid, admin_group_uuid
+                "Created READ policy for resource=%s group=%s", resource_uuid, group_uuid
             )
             return True
         _logger.error(
@@ -415,9 +447,9 @@ class DSpaceClient:
     # High-level operation
     # ------------------------------------------------------------------
 
-    def restrict_to_admin(self, resource_uuid: str, admin_group_uuid: str, label: str) -> bool:
+    def restrict_read_to_group(self, resource_uuid: str, group_uuid: str, group_name: str, label: str) -> bool:
         """
-        Replace all READ policies on *resource_uuid* with a single Administrator-only policy.
+        Replace all READ policies on *resource_uuid* with a single policy for *group_name*.
         *label* is used only for log messages (e.g. 'bundle', 'bitstream <name>').
         """
         existing_policies = self.get_read_policies(resource_uuid)
@@ -432,9 +464,9 @@ class DSpaceClient:
             if policy_id is not None:
                 all_deleted = self.delete_policy(policy_id) and all_deleted
 
-        created = self.create_read_policy(resource_uuid, admin_group_uuid)
+        created = self.create_read_policy(resource_uuid, group_uuid)
         if all_deleted and created:
-            _logger.info("  %s [%s]: READ policy set to Administrator only.", label, resource_uuid)
+            _logger.info("  %s [%s]: READ policy set to '%s' only.", label, resource_uuid, group_name)
             return True
         _logger.error("  %s [%s]: failed to fully update READ policy.", label, resource_uuid)
         return False
@@ -476,10 +508,11 @@ def collect_handles(raw_handles: Optional[str], repeated_handles: Optional[list[
 def process_handle(
     client: DSpaceClient,
     handle: str,
-    admin_group_uuid: str,
+    group_uuid: str,
+    group_name: str,
     continue_on_bitstream_error: bool = False,
 ) -> dict[str, Any]:
-    """Process one handle and restrict bundle + bitstreams to Administrator group."""
+    """Process one handle and set bundle + bitstreams READ policy to the target group."""
     result: dict[str, Any] = {
         "handle": handle,
         "success": False,
@@ -499,42 +532,30 @@ def process_handle(
 
     _logger.info("  Resolved to item UUID: %s", item_uuid)
 
-    original_bundle = client.get_original_bundle(item_uuid)
-    if not original_bundle:
+    original_bundles = client.get_original_bundles(item_uuid)
+    if not original_bundles:
         _logger.warning("Skipping handle %s (no ORIGINAL bundle).", handle)
         result["reason"] = "missing_original_bundle"
         return result
 
-    bundle_uuid = original_bundle["uuid"]
-    _logger.info("  ORIGINAL bundle UUID: %s", bundle_uuid)
-
-    bitstreams = client.get_bitstreams(bundle_uuid)
-    _logger.info("  Found %d bitstream(s) in ORIGINAL bundle.", len(bitstreams))
-    result["bitstreams_attempted"] = len(bitstreams)
-
-    if not client.restrict_to_admin(bundle_uuid, admin_group_uuid, "ORIGINAL bundle"):
-        result["reason"] = "bundle_policy_update_failed"
-        return result
+    _logger.info("  Found %d ORIGINAL bundle(s).", len(original_bundles))
 
     failed_bitstreams = 0
-    for bitstream in bitstreams:
-        bitstream_uuid = bitstream["uuid"]
-        bitstream_name = bitstream.get("name", bitstream_uuid)
-        if not client.restrict_to_admin(
-            bitstream_uuid,
-            admin_group_uuid,
-            f"bitstream '{bitstream_name}'",
-        ):
-            failed_bitstreams += 1
-            result["bitstreams_failed"] = failed_bitstreams
-            if continue_on_bitstream_error:
-                _logger.warning(
-                    "  bitstream '%s' [%s]: failed; continuing due to --continue-on-bitstream-error",
-                    bitstream_name,
-                    bitstream_uuid,
-                )
-                continue
-            result["reason"] = "bitstream_policy_update_failed"
+    for bundle_index, original_bundle in enumerate(original_bundles, start=1):
+        bundle_uuid = original_bundle["uuid"]
+        bundle_label = (
+            "ORIGINAL bundle"
+            if len(original_bundles) == 1
+            else f"ORIGINAL bundle #{bundle_index}/{len(original_bundles)}"
+        )
+        _logger.info("  %s UUID: %s", bundle_label, bundle_uuid)
+
+        bitstreams = client.get_bitstreams(bundle_uuid)
+        _logger.info("  Found %d bitstream(s) in %s.", len(bitstreams), bundle_label)
+        result["bitstreams_attempted"] += len(bitstreams)
+
+        if not client.restrict_read_to_group(bundle_uuid, group_uuid, group_name, bundle_label):
+            result["reason"] = "bundle_policy_update_failed"
             _logger.info(
                 "Handle %s summary: bitstreams attempted=%d, failed=%d",
                 handle,
@@ -542,6 +563,33 @@ def process_handle(
                 result["bitstreams_failed"],
             )
             return result
+
+        for bitstream in bitstreams:
+            bitstream_uuid = bitstream["uuid"]
+            bitstream_name = bitstream.get("name", bitstream_uuid)
+            if not client.restrict_read_to_group(
+                bitstream_uuid,
+                group_uuid,
+                group_name,
+                f"bitstream '{bitstream_name}'",
+            ):
+                failed_bitstreams += 1
+                result["bitstreams_failed"] = failed_bitstreams
+                if continue_on_bitstream_error:
+                    _logger.warning(
+                        "  bitstream '%s' [%s]: failed; continuing due to --continue-on-bitstream-error",
+                        bitstream_name,
+                        bitstream_uuid,
+                    )
+                    continue
+                result["reason"] = "bitstream_policy_update_failed"
+                _logger.info(
+                    "Handle %s summary: bitstreams attempted=%d, failed=%d",
+                    handle,
+                    result["bitstreams_attempted"],
+                    result["bitstreams_failed"],
+                )
+                return result
 
     if failed_bitstreams > 0:
         _logger.warning(
@@ -575,7 +623,8 @@ def process_handle(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Set READ policies on ORIGINAL bundles/bitstreams to Administrator only."
+        description="Set READ policies on ORIGINAL bundles/bitstreams to a single group "
+                    "(default: Administrator; use --group Anonymous to make them public)."
     )
     handles_group = parser.add_mutually_exclusive_group(required=True)
     handles_group.add_argument(
@@ -597,13 +646,29 @@ def main() -> None:
     )
     parser.add_argument(
         "--email",
-        required=True,
-        help="Admin account e-mail used for login.",
+        help="Admin account e-mail used for user/password login. "
+             "Not needed when --bearer-token is given.",
     )
     parser.add_argument(
         "--password",
-        required=True,
-        help="Admin password",
+        help="Admin password. Not needed when --bearer-token is given.",
+    )
+    parser.add_argument(
+        "--bearer-token",
+        help=(
+            "Pre-obtained DSpace JWT to authenticate with instead of --email/--password. "
+            "Use this when the instance only allows Shibboleth/SAML login: log in via the "
+            "browser, then copy the token from the 'Authorization: Bearer <token>' request "
+            "header (DevTools -> Network). The token is short-lived, so run promptly."
+        ),
+    )
+    parser.add_argument(
+        "--group",
+        default="Administrator",
+        help=(
+            "Exact name of the group that should get the READ policy "
+            "(default: 'Administrator'). Use 'Anonymous' to make the files publicly readable."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -651,11 +716,20 @@ def main() -> None:
         _logger.error("--retry-backoff-sec must be >= 0")
         sys.exit(1)
 
+    use_token = bool(args.bearer_token)
+    if not use_token and not (args.email and args.password):
+        _logger.error(
+            "Provide either --bearer-token, or both --email and --password."
+        )
+        sys.exit(1)
+
     _logger.info(
-        "Arguments: base_url=%s, email=%s, dry_run=%s, timeout_sec=%s, retry_count=%s, "
-        "retry_backoff_sec=%s, continue_on_bitstream_error=%s, handles_mode=%s",
+        "Arguments: base_url=%s, auth=%s, email=%s, group=%s, dry_run=%s, timeout_sec=%s, "
+        "retry_count=%s, retry_backoff_sec=%s, continue_on_bitstream_error=%s, handles_mode=%s",
         args.base_url,
-        args.email,
+        "bearer-token" if use_token else "password",
+        args.email if not use_token else "<token>",
+        args.group,
         args.dry_run,
         args.timeout_sec,
         args.retry_count,
@@ -679,8 +753,11 @@ def main() -> None:
     )
 
     try:
-        client.login(args.email, args.password)
-        admin_group_uuid = client.find_administrator_group_uuid()
+        if use_token:
+            client.use_bearer_token(args.bearer_token)
+        else:
+            client.login(args.email, args.password)
+        group_uuid = client.find_group_uuid(args.group)
 
         success_count = 0
         failure_count = 0
@@ -692,7 +769,8 @@ def main() -> None:
             handle_result = process_handle(
                 client,
                 handle,
-                admin_group_uuid,
+                group_uuid,
+                args.group,
                 continue_on_bitstream_error=args.continue_on_bitstream_error,
             )
 


### PR DESCRIPTION
## Problem description
- Updates READ policies on each item’s ORIGINAL bundle and all its bitstreams so only the Administrator group keeps READ access.
- Resolves handles to item UUIDs with fallback search when primary PID lookup fails.
- Removes existing READ resource policies on each target resource and creates one new Administrator READ policy.
- Adds resilient API behavior with explicit request timeout, retry count, and exponential backoff settings.
- Adds optional continue-on-bitstream-error mode so one failed bitstream does not stop the rest of the handle.
- Adds run reporting with per-handle bitstream attempted/failed counts and a final aggregate failure report by reason.